### PR TITLE
Fix 1-dim Nada Array bug

### DIFF
--- a/nada_algebra/array.py
+++ b/nada_algebra/array.py
@@ -208,9 +208,7 @@ class NadaArray:
             NadaArray: A new NadaArray representing the result of matrix multiplication.
         """
         result = self.inner @ other.inner
-        if not isinstance(result, np.ndarray):
-            result = np.array(result)
-        return NadaArray(result)
+        return NadaArray(np.array(result))
 
     @property
     def ndim(self) -> int:


### PR DESCRIPTION
So there's this thing in Numpy where if you matmul two 1-dim arrays, it returns the inner value instead of another NumPy array (e.g. `np.array([1,2,3]) @ np.array([1,2,3]))` will return a `np.int64`)
This means that when you do this with NadaArrays, you can end up with a NadaArray that has an inner value of e.g. type `SecretInteger` instead of `np.array<SecretInteger>` leading to all sorts of issues down the line