### PR TITLE
Remove empty func

### DIFF
--- a/nada_algebra/funcs.py
+++ b/nada_algebra/funcs.py
@@ -260,19 +260,6 @@ def hstack(arr_list: list) -> NadaArray:
     return NadaArray(np.hstack(arr_list))
 
 
-def empty(arr: NadaArray) -> bool:
-    """
-    Returns whether provided array is empty or not.
-
-    Args:
-        arr (NadaArray): Input array.
-
-    Returns:
-        bool: Whether array is empty or not.
-    """
-    return arr.empty
-
-
 def ndim(arr: NadaArray) -> int:
     """
     Returns number of array dimensions.


### PR DESCRIPTION
There is a function `np.empty` that has a different behaviour. Decided to remove it to avoid confusion