### PR TITLE
Chore: Update version 0.5.0

### DIFF
--- a/examples/broadcasting/tests/broadcasting.yaml
+++ b/examples/broadcasting/tests/broadcasting.yaml
@@ -1,35 +1,18 @@
----
 program: broadcasting
 inputs:
-  B_1:
-    SecretInteger: "3"
-  A_0:
-    SecretInteger: "3"
-  C_1:
-    SecretInteger: "3"
-  B_0:
-    SecretInteger: "3"
-  D_0:
-    SecretInteger: "3"
-  C_2:
-    SecretInteger: "3"
-  C_0:
-    SecretInteger: "3"
-  A_2:
-    SecretInteger: "3"
-  A_1:
-    SecretInteger: "3"
-  D_1:
-    SecretInteger: "3"
-  B_2:
-    SecretInteger: "3"
-  D_2:
-    SecretInteger: "3"
-
+  B_1: 3
+  A_0: 3
+  C_1: 3
+  B_0: 3
+  D_0: 3
+  C_2: 3
+  C_0: 3
+  A_2: 3
+  A_1: 3
+  D_1: 3
+  B_2: 3
+  D_2: 3
 expected_outputs:
-  my_output_1:
-    SecretInteger: "-3"
-  my_output_2:
-    SecretInteger: "-3"
-  my_output_0:
-    SecretInteger: "-3"
+  my_output_1: -3
+  my_output_2: -3
+  my_output_0: -3

--- a/examples/dot_product/tests/dot_product.yaml
+++ b/examples/dot_product/tests/dot_product.yaml
@@ -1,20 +1,10 @@
----
 program: dot_product
 inputs:
-
-  A_0:
-    SecretInteger: "3"
-  A_1:
-    SecretInteger: "3"
-  A_2:
-    SecretInteger: "3"
-  B_0:
-    SecretInteger: "3"
-  B_1:
-    SecretInteger: "3"
-  B_2:
-    SecretInteger: "3"
-
+  A_0: 3
+  A_1: 3
+  A_2: 3
+  B_0: 3
+  B_1: 3
+  B_2: 3
 expected_outputs:
-  my_output:
-    SecretInteger: "27"
+  my_output: 27

--- a/examples/linear_regression/tests/determinant-3.yaml
+++ b/examples/linear_regression/tests/determinant-3.yaml
@@ -1,24 +1,13 @@
----
 program: determinant
 inputs:
-  A_0_0:
-    SecretInteger: "1"
-  A_0_1:
-    SecretInteger: "0"
-  A_0_2:
-    SecretInteger: "0"
-  A_1_0:
-    SecretInteger: "0"
-  A_1_1:
-    SecretInteger: "2"
-  A_1_2:
-    SecretInteger: "0"
-  A_2_0:
-    SecretInteger: "0"
-  A_2_1:
-    SecretInteger: "0"
-  A_2_2:
-    SecretInteger: "3"
+  A_0_0: 1
+  A_0_1: 0
+  A_0_2: 0
+  A_1_0: 0
+  A_1_1: 2
+  A_1_2: 0
+  A_2_0: 0
+  A_2_1: 0
+  A_2_2: 3
 expected_outputs:
-  my_output:
-    Integer: "6"
+  my_output: 6

--- a/examples/linear_regression/tests/determinant_1.yaml
+++ b/examples/linear_regression/tests/determinant_1.yaml
@@ -1,24 +1,13 @@
----
 program: determinant
 inputs:
-  A_0_0:
-    SecretInteger: "1"
-  A_0_1:
-    SecretInteger: "2"
-  A_0_2:
-    SecretInteger: "3"
-  A_1_0:
-    SecretInteger: "4"
-  A_1_1:
-    SecretInteger: "5"
-  A_1_2:
-    SecretInteger: "6"
-  A_2_0:
-    SecretInteger: "7"
-  A_2_1:
-    SecretInteger: "8"
-  A_2_2:
-    SecretInteger: "10"
+  A_0_0: 1
+  A_0_1: 2
+  A_0_2: 3
+  A_1_0: 4
+  A_1_1: 5
+  A_1_2: 6
+  A_2_0: 7
+  A_2_1: 8
+  A_2_2: 10
 expected_outputs:
-  my_output:
-    Integer: "-3"
+  my_output: -3

--- a/examples/linear_regression/tests/determinant_2.yaml
+++ b/examples/linear_regression/tests/determinant_2.yaml
@@ -1,24 +1,13 @@
----
 program: determinant
 inputs:
-  A_0_1:
-    SecretInteger: "3"
-  A_2_2:
-    SecretInteger: "3"
-  A_1_0:
-    SecretInteger: "3"
-  A_1_2:
-    SecretInteger: "3"
-  A_2_0:
-    SecretInteger: "3"
-  A_0_0:
-    SecretInteger: "3"
-  A_1_1:
-    SecretInteger: "3"
-  A_2_1:
-    SecretInteger: "3"
-  A_0_2:
-    SecretInteger: "3"
+  A_0_1: 3
+  A_2_2: 3
+  A_1_0: 3
+  A_1_2: 3
+  A_2_0: 3
+  A_0_0: 3
+  A_1_1: 3
+  A_2_1: 3
+  A_0_2: 3
 expected_outputs:
-  my_output:
-    Integer: "0"
+  my_output: 0

--- a/examples/linear_regression/tests/gauss_jordan.yaml
+++ b/examples/linear_regression/tests/gauss_jordan.yaml
@@ -1,42 +1,22 @@
----
 program: gauss_jordan
 inputs:
-  A_0_0:
-    SecretInteger: "2"
-  A_0_1:
-    SecretInteger: "4"
-  A_0_2:
-    SecretInteger: "6"
-  A_1_0:
-    SecretInteger: "1"
-  A_1_1:
-    SecretInteger: "3"
-  A_1_2:
-    SecretInteger: "5"
-  A_2_0:
-    SecretInteger: "3"
-  A_2_1:
-    SecretInteger: "1"
-  A_2_2:
-    SecretInteger: "2"
-  B: 
-    Integer: "456"
+  A_0_0: 2
+  A_0_1: 4
+  A_0_2: 6
+  A_1_0: 1
+  A_1_1: 3
+  A_1_2: 5
+  A_2_0: 3
+  A_2_1: 1
+  A_2_2: 2
+  B: 456
 expected_outputs:
-  my_output_0_0:
-    Integer: "1"
-  my_output_0_1:
-    Integer: "0"
-  my_output_0_2:
-    Integer: "0"
-  my_output_1_0:
-    Integer: "0"
-  my_output_1_1:
-    Integer: "1"
-  my_output_1_2:
-    Integer: "0"
-  my_output_2_0:
-    Integer: "0"
-  my_output_2_1:
-    Integer: "0"
-  my_output_2_2:
-    Integer: "1"
+  my_output_0_0: 1
+  my_output_0_1: 0
+  my_output_0_2: 0
+  my_output_1_0: 0
+  my_output_1_1: 1
+  my_output_1_2: 0
+  my_output_2_0: 0
+  my_output_2_1: 0
+  my_output_2_2: 1

--- a/examples/linear_regression/tests/linear_regression.yaml
+++ b/examples/linear_regression/tests/linear_regression.yaml
@@ -1,38 +1,19 @@
----
 program: linear_regression
 inputs:
-  A_0_0:
-      SecretInteger: "-256"
-  A_0_1:
-      SecretInteger: "-199"
-  A_0_2:
-      SecretInteger: "-142"
-  A_1_0:
-      SecretInteger: "-85"
-  A_1_1:
-      SecretInteger: "-28"
-  A_1_2:
-      SecretInteger: "28"
-  A_2_0:
-      SecretInteger: "85"
-  A_2_1:
-      SecretInteger: "142"
-  A_2_2:
-      SecretInteger: "256"
-  b_0:
-      SecretInteger: "-256"
-  b_1:
-      SecretInteger: "-199"
-  b_2:
-      SecretInteger: "-142"
-#   lambda_0: 
-#     Integer: "1"
+  A_0_0: -256
+  A_0_1: -199
+  A_0_2: -142
+  A_1_0: -85
+  A_1_1: -28
+  A_1_2: 28
+  A_2_0: 85
+  A_2_1: 142
+  A_2_2: 256
+  b_0: -256
+  b_1: -199
+  b_2: -142
 expected_outputs:
-  b:
-    SecretInteger: "330643400256"
-  w_0:
-    SecretInteger: "1102041164640"
-  w_1:
-    SecretInteger: "-993683999568"
-  w_2:
-    SecretInteger: "1868226984"
+  b: 330643400256
+  w_0: 1102041164640
+  w_1: -993683999568
+  w_2: 1868226984

--- a/examples/linear_regression/tests/linear_regression_1.yaml
+++ b/examples/linear_regression/tests/linear_regression_1.yaml
@@ -1,38 +1,19 @@
----
 program: linear_regression
 inputs:
-  A_0_0:
-      SecretInteger: "-256"
-  A_0_1:
-      SecretInteger: "-199"
-  A_0_2:
-      SecretInteger: "-142"
-  A_1_0:
-      SecretInteger: "-85"
-  A_1_1:
-      SecretInteger: "-28"
-  A_1_2:
-      SecretInteger: "28"
-  A_2_0:
-      SecretInteger: "85"
-  A_2_1:
-      SecretInteger: "142"
-  A_2_2:
-      SecretInteger: "256"
-  b_0:
-      SecretInteger: "-256"
-  b_1:
-      SecretInteger: "-199"
-  b_2:
-      SecretInteger: "-142"
-#   lambda_0: 
-#     Integer: "1"
+  A_0_0: -256
+  A_0_1: -199
+  A_0_2: -142
+  A_1_0: -85
+  A_1_1: -28
+  A_1_2: 28
+  A_2_0: 85
+  A_2_1: 142
+  A_2_2: 256
+  b_0: -256
+  b_1: -199
+  b_2: -142
 expected_outputs:
-  b:
-    SecretInteger: "330643400256"
-  w_0:
-    SecretInteger: "1102041164640"
-  w_1:
-    SecretInteger: "-993683999568"
-  w_2:
-    SecretInteger: "1868226984"
+  b: 330643400256
+  w_0: 1102041164640
+  w_1: -993683999568
+  w_2: 1868226984

--- a/examples/linear_regression/tests/linear_regression_2.yaml
+++ b/examples/linear_regression/tests/linear_regression_2.yaml
@@ -1,38 +1,19 @@
----
 program: linear_regression
 inputs:
-  A_0_0:
-      SecretInteger: "116"
-  A_0_1:
-      SecretInteger: "206"
-  A_0_2:
-      SecretInteger: "-115"
-  A_1_0:
-      SecretInteger: "-256"
-  A_1_1:
-      SecretInteger: "-168"
-  A_1_2:
-      SecretInteger: "152"
-  A_2_0:
-      SecretInteger: "3"
-  A_2_1:
-      SecretInteger: "-142"
-  A_2_2:
-      SecretInteger: "-33"
-  b_0:
-      SecretInteger: "117"
-  b_1:
-      SecretInteger: "-116"
-  b_2:
-      SecretInteger: "256"
-#   lambda_0: 
-#     Integer: "0"
+  A_0_0: 116
+  A_0_1: 206
+  A_0_2: -115
+  A_1_0: -256
+  A_1_1: -168
+  A_1_2: 152
+  A_2_0: 3
+  A_2_1: -142
+  A_2_2: -33
+  b_0: 117
+  b_1: -116
+  b_2: 256
 expected_outputs:
-  b:
-    SecretInteger: "7496337347136"
-  w_0:
-    SecretInteger: "-9750037619520"
-  w_1:
-    SecretInteger: "-6822441714528"
-  w_2:
-    SecretInteger: "-29682598492800"
+  b: 7496337347136
+  w_0: -9750037619520
+  w_1: -6822441714528
+  w_2: -29682598492800

--- a/examples/linear_regression/tests/linear_regression_256_1.yaml
+++ b/examples/linear_regression/tests/linear_regression_256_1.yaml
@@ -1,38 +1,19 @@
----
-program: linear_regression_256  
+program: linear_regression_256
 inputs:
-  A_0_0:
-      SecretInteger: "-256"
-  A_0_1:
-      SecretInteger: "-199"
-  A_0_2:
-      SecretInteger: "-142"
-  A_1_0:
-      SecretInteger: "-85"
-  A_1_1:
-      SecretInteger: "-28"
-  A_1_2:
-      SecretInteger: "28"
-  A_2_0:
-      SecretInteger: "85"
-  A_2_1:
-      SecretInteger: "142"
-  A_2_2:
-      SecretInteger: "256"
-  b_0:
-      SecretInteger: "-256"
-  b_1:
-      SecretInteger: "-199"
-  b_2:
-      SecretInteger: "-142"
-#   lambda_0: 
-#     Integer: "1"
+  A_0_0: -256
+  A_0_1: -199
+  A_0_2: -142
+  A_1_0: -85
+  A_1_1: -28
+  A_1_2: 28
+  A_2_0: 85
+  A_2_1: 142
+  A_2_2: 256
+  b_0: -256
+  b_1: -199
+  b_2: -142
 expected_outputs:
-  b:
-    SecretInteger: "330643400256"
-  w_0:
-    SecretInteger: "1102041164640"
-  w_1:
-    SecretInteger: "-993683999568"
-  w_2:
-    SecretInteger: "1868226984"
+  b: 330643400256
+  w_0: 1102041164640
+  w_1: -993683999568
+  w_2: 1868226984

--- a/examples/linear_regression/tests/linear_regression_256_2.yaml
+++ b/examples/linear_regression/tests/linear_regression_256_2.yaml
@@ -1,38 +1,19 @@
----
 program: linear_regression_256
 inputs:
-  A_0_0:
-      SecretInteger: "116"
-  A_0_1:
-      SecretInteger: "206"
-  A_0_2:
-      SecretInteger: "-115"
-  A_1_0:
-      SecretInteger: "-256"
-  A_1_1:
-      SecretInteger: "-168"
-  A_1_2:
-      SecretInteger: "152"
-  A_2_0:
-      SecretInteger: "3"
-  A_2_1:
-      SecretInteger: "-142"
-  A_2_2:
-      SecretInteger: "-33"
-  b_0:
-      SecretInteger: "117"
-  b_1:
-      SecretInteger: "-116"
-  b_2:
-      SecretInteger: "256"
-#   lambda_0: 
-#     Integer: "0"
+  A_0_0: 116
+  A_0_1: 206
+  A_0_2: -115
+  A_1_0: -256
+  A_1_1: -168
+  A_1_2: 152
+  A_2_0: 3
+  A_2_1: -142
+  A_2_2: -33
+  b_0: 117
+  b_1: -116
+  b_2: 256
 expected_outputs:
-  b:
-    SecretInteger: "7496337347136"
-  w_0:
-    SecretInteger: "-9750037619520"
-  w_1:
-    SecretInteger: "-6822441714528"
-  w_2:
-    SecretInteger: "-29682598492800"
+  b: 7496337347136
+  w_0: -9750037619520
+  w_1: -6822441714528
+  w_2: -29682598492800

--- a/examples/linear_regression/tests/matrix_inverse.yaml
+++ b/examples/linear_regression/tests/matrix_inverse.yaml
@@ -1,123 +1,62 @@
----
 program: matrix_inverse
 inputs:
-  A_0_0:
-      SecretInteger: "-256"
-  A_0_1:
-      SecretInteger: "256"
-  A_0_2:
-      SecretInteger: "-251"
-  A_0_3:
-      SecretInteger: "158"
-  A_0_4:
-      SecretInteger: "141"
-  A_0_5:
-      SecretInteger: "-212"
-  A_1_0:
-      SecretInteger: "121"
-  A_1_1:
-      SecretInteger: "-7"
-  A_1_2:
-      SecretInteger: "-6"
-  A_1_3:
-      SecretInteger: "-29"
-  A_1_4:
-      SecretInteger: "51"
-  A_1_5:
-      SecretInteger: "163"
-  A_2_0:
-      SecretInteger: "227"
-  A_2_1:
-      SecretInteger: "19"
-  A_2_2:
-      SecretInteger: "-150"
-  A_2_3:
-      SecretInteger: "43"
-  A_2_4:
-      SecretInteger: "-136"
-  A_2_5:
-      SecretInteger: "157"
-  A_3_0:
-      SecretInteger: "101"
-  A_3_1:
-      SecretInteger: "190"
-  A_3_2:
-      SecretInteger: "-178"
-  A_3_3:
-      SecretInteger: "59"
-  A_3_4:
-      SecretInteger: "204"
-  A_3_5:
-      SecretInteger: "-194"
-  A_4_0:
-      SecretInteger: "-252"
-  A_4_1:
-      SecretInteger: "-45"
-  A_4_2:
-      SecretInteger: "-9"
-  A_4_3:
-      SecretInteger: "157"
-  A_4_4:
-      SecretInteger: "92"
-  A_4_5:
-      SecretInteger: "-149"
-  A_5_0:
-      SecretInteger: "-208"
-  A_5_1:
-      SecretInteger: "29"
-  A_5_2:
-      SecretInteger: "60"
-  A_5_3:
-      SecretInteger: "2"
-  A_5_4:
-      SecretInteger: "-132"
-  A_5_5:
-      SecretInteger: "-54"
-  b_0:
-      SecretInteger: "-255"
-  b_1:
-      SecretInteger: "-108"
-  b_2:
-      SecretInteger: "-183"
-  b_3:
-      SecretInteger: "73"
-  b_4:
-      SecretInteger: "-92"
-  b_5:
-      SecretInteger: "-65"
-  B: 
-    Integer: "456"
+  A_0_0: -256
+  A_0_1: 256
+  A_0_2: -251
+  A_0_3: 158
+  A_0_4: 141
+  A_0_5: -212
+  A_1_0: 121
+  A_1_1: -7
+  A_1_2: -6
+  A_1_3: -29
+  A_1_4: 51
+  A_1_5: 163
+  A_2_0: 227
+  A_2_1: 19
+  A_2_2: -150
+  A_2_3: 43
+  A_2_4: -136
+  A_2_5: 157
+  A_3_0: 101
+  A_3_1: 190
+  A_3_2: -178
+  A_3_3: 59
+  A_3_4: 204
+  A_3_5: -194
+  A_4_0: -252
+  A_4_1: -45
+  A_4_2: -9
+  A_4_3: 157
+  A_4_4: 92
+  A_4_5: -149
+  A_5_0: -208
+  A_5_1: 29
+  A_5_2: 60
+  A_5_3: 2
+  A_5_4: -132
+  A_5_5: -54
+  b_0: -255
+  b_1: -108
+  b_2: -183
+  b_3: 73
+  b_4: -92
+  b_5: -65
+  B: 456
 expected_outputs:
-    my_output_0_0:
-        SecretInteger: "1"
-    my_output_0_1:
-        SecretInteger: "0"
-    my_output_0_2:
-        SecretInteger: "0"
-    my_output_0_3:
-        SecretInteger: "0"
-    my_output_1_0:
-        SecretInteger: "0"
-    my_output_1_1:
-        SecretInteger: "1"
-    my_output_1_2:
-        SecretInteger: "0"
-    my_output_1_3:
-        SecretInteger: "0"
-    my_output_2_0:
-        SecretInteger: "0"
-    my_output_2_1:
-        SecretInteger: "0"
-    my_output_2_2:
-        SecretInteger: "1"
-    my_output_2_3:
-        SecretInteger: "0"
-    my_output_3_0:
-        SecretInteger: "0"
-    my_output_3_1:
-        SecretInteger: "0"
-    my_output_3_2:
-        SecretInteger: "0"
-    my_output_3_3:
-        SecretInteger: "1"
-   
+  my_output_0_0: 1
+  my_output_0_1: 0
+  my_output_0_2: 0
+  my_output_0_3: 0
+  my_output_1_0: 0
+  my_output_1_1: 1
+  my_output_1_2: 0
+  my_output_1_3: 0
+  my_output_2_0: 0
+  my_output_2_1: 0
+  my_output_2_2: 1
+  my_output_2_3: 0
+  my_output_3_0: 0
+  my_output_3_1: 0
+  my_output_3_2: 0
+  my_output_3_3: 1

--- a/examples/linear_regression/tests/modular_inverse.yaml
+++ b/examples/linear_regression/tests/modular_inverse.yaml
@@ -1,8 +1,5 @@
----
 program: modular_inverse
 inputs:
-  A_0:
-    SecretInteger: "982554"
+  A_0: 982554
 expected_outputs:
-  my_output:
-    SecretInteger: "1"
+  my_output: 1

--- a/examples/matrix_multiplication/tests/matrix_multiplication.yaml
+++ b/examples/matrix_multiplication/tests/matrix_multiplication.yaml
@@ -1,57 +1,30 @@
 program: matrix_multiplication
 inputs:
-  A_0_0:
-    SecretInteger: '1'
-  A_0_1:
-    SecretInteger: '2'
-  A_0_2:
-    SecretInteger: '3'
-  A_1_0:
-    SecretInteger: '4'
-  A_1_1:
-    SecretInteger: '5'
-  A_1_2:
-    SecretInteger: '6'
-  A_2_0:
-    SecretInteger: '7'
-  A_2_1:
-    SecretInteger: '8'
-  A_2_2:
-    SecretInteger: '9'
-  B_0_0:
-    SecretInteger: '1'
-  B_0_1:
-    SecretInteger: '2'
-  B_0_2:
-    SecretInteger: '3'
-  B_1_0:
-    SecretInteger: '4'
-  B_1_1:
-    SecretInteger: '5'
-  B_1_2:
-    SecretInteger: '6'
-  B_2_0:
-    SecretInteger: '7'
-  B_2_1:
-    SecretInteger: '8'
-  B_2_2:
-    SecretInteger: '9'
+  A_0_0: 1
+  A_0_1: 2
+  A_0_2: 3
+  A_1_0: 4
+  A_1_1: 5
+  A_1_2: 6
+  A_2_0: 7
+  A_2_1: 8
+  A_2_2: 9
+  B_0_0: 1
+  B_0_1: 2
+  B_0_2: 3
+  B_1_0: 4
+  B_1_1: 5
+  B_1_2: 6
+  B_2_0: 7
+  B_2_1: 8
+  B_2_2: 9
 expected_outputs:
-  my_output_0_0:
-    SecretInteger: '30'
-  my_output_0_1:
-    SecretInteger: '36'
-  my_output_0_2:
-    SecretInteger: '42'
-  my_output_1_0:
-    SecretInteger: '66'
-  my_output_1_1:
-    SecretInteger: '81'
-  my_output_1_2:
-    SecretInteger: '96'
-  my_output_2_0:
-    SecretInteger: '102'
-  my_output_2_1:
-    SecretInteger: '126'
-  my_output_2_2:
-    SecretInteger: '150'
+  my_output_0_0: 30
+  my_output_0_1: 36
+  my_output_0_2: 42
+  my_output_1_0: 66
+  my_output_1_1: 81
+  my_output_1_2: 96
+  my_output_2_0: 102
+  my_output_2_1: 126
+  my_output_2_2: 150

--- a/examples/rational_numbers/tests/rational_numbers.yaml
+++ b/examples/rational_numbers/tests/rational_numbers.yaml
@@ -1,9 +1,6 @@
 program: rational_numbers
 inputs:
-  my_input_0:
-    SecretInteger: '209715'
-  my_input_1:
-    SecretInteger: '294912'
+  my_input_0: 209715
+  my_input_1: 294912
 expected_outputs:
-  my_output:
-    SecretInteger: '294912'
+  my_output: 294912

--- a/nada_numpy/array.py
+++ b/nada_numpy/array.py
@@ -20,6 +20,7 @@ from nada_numpy.types import (Rational, SecretRational, fxp_abs, get_log_scale,
                               public_rational, rational, secret_rational, sign)
 from nada_numpy.utils import copy_metadata
 
+
 class NadaArray:  # pylint:disable=too-many-public-methods
     """
     Represents an array-like object with additional functionality.

--- a/poetry.lock
+++ b/poetry.lock
@@ -110,13 +110,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2024.7.4"
+version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
-    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
+    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
+    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
 ]
 
 [[package]]
@@ -331,61 +331,61 @@ grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
 
 [[package]]
 name = "grpcio"
-version = "1.66.0"
+version = "1.66.1"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "grpcio-1.66.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:ad7256f224437b2c29c2bef98ddd3130454c5b1ab1f0471fc11794cefd4dbd3d"},
-    {file = "grpcio-1.66.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:5f4b3357e59dfba9140a51597287297bc638710d6a163f99ee14efc19967a821"},
-    {file = "grpcio-1.66.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:e8d20308eeae15b3e182f47876f05acbdec1eebd9473a9814a44e46ec4a84c04"},
-    {file = "grpcio-1.66.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1eb03524d0f55b965d6c86aa44e5db9e5eaa15f9ed3b164621e652e5b927f4b8"},
-    {file = "grpcio-1.66.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37514b68a42e9cf24536345d3cf9e580ffd29117c158b4eeea34625200256067"},
-    {file = "grpcio-1.66.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:516fdbc8e156db71a004bc431a6303bca24cfde186babe96dde7bd01e8f0cc70"},
-    {file = "grpcio-1.66.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d0439a970d65327de21c299ea0e0c2ad0987cdaf18ba5066621dea5f427f922b"},
-    {file = "grpcio-1.66.0-cp310-cp310-win32.whl", hash = "sha256:5f93fc84b72bbc7b84a42f3ca9dc055fa00d2303d9803be011ebf7a10a4eb833"},
-    {file = "grpcio-1.66.0-cp310-cp310-win_amd64.whl", hash = "sha256:8fc5c710ddd51b5a0dc36ef1b6663430aa620e0ce029b87b150dafd313b978c3"},
-    {file = "grpcio-1.66.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dd614370e939f9fceeeb2915111a0795271b4c11dfb5fc0f58449bee40c726a5"},
-    {file = "grpcio-1.66.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:245b08f9b3c645a6a623f3ed4fa43dcfcd6ad701eb9c32511c1bb7380e8c3d23"},
-    {file = "grpcio-1.66.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:aaf30c75cbaf30e561ca45f21eb1f729f0fab3f15c592c1074795ed43e3ff96f"},
-    {file = "grpcio-1.66.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49234580a073ce7ac490112f6c67c874cbcb27804c4525978cdb21ba7f3f193c"},
-    {file = "grpcio-1.66.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de9e20a0acb709dcfa15a622c91f584f12c9739a79c47999f73435d2b3cc8a3b"},
-    {file = "grpcio-1.66.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:bc008c6afa1e7c8df99bd9154abc4f0470d26b7730ca2521122e99e771baa8c7"},
-    {file = "grpcio-1.66.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:50cea8ce2552865b87e3dffbb85eb21e6b98d928621600c0feda2f02449cd837"},
-    {file = "grpcio-1.66.0-cp311-cp311-win32.whl", hash = "sha256:508411df1f2b7cfa05d4d7dbf3d576fe4f949cd61c03f3a6f0378c84e3d7b963"},
-    {file = "grpcio-1.66.0-cp311-cp311-win_amd64.whl", hash = "sha256:6d586a95c05c82a5354be48bb4537e1accaf2472d8eb7e9086d844cbff934482"},
-    {file = "grpcio-1.66.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:5ea27f4ce8c0daccfdd2c7961e6ba404b6599f47c948415c4cca5728739107a3"},
-    {file = "grpcio-1.66.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:296a45ea835e12a1cc35ab0c57e455346c272af7b0d178e29c67742167262b4c"},
-    {file = "grpcio-1.66.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:e36fa838ac1d6c87198ca149cbfcc92e1af06bb8c8cd852622f8e58f33ea3324"},
-    {file = "grpcio-1.66.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:684a4c07883cbd4ac864f0d08d927267404f5f0c76f31c85f9bbe05f2daae2f2"},
-    {file = "grpcio-1.66.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3084e590e857ba7585ae91078e4c9b6ef55aaf1dc343ce26400ba59a146eada"},
-    {file = "grpcio-1.66.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:526d4f6ca19f31b25606d5c470ecba55c0b22707b524e4de8987919e8920437d"},
-    {file = "grpcio-1.66.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:423ae18637cd99ddcf2e5a6851c61828c49e9b9d022d0442d979b4f230109787"},
-    {file = "grpcio-1.66.0-cp312-cp312-win32.whl", hash = "sha256:7bc9d823e05d63a87511fb456dcc48dc0fced86c282bf60229675e7ee7aac1a1"},
-    {file = "grpcio-1.66.0-cp312-cp312-win_amd64.whl", hash = "sha256:230cdd696751e7eb1395718cd308234749daa217bb8d128f00357dc4df102558"},
-    {file = "grpcio-1.66.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:0f3010bf46b2a01c9e40644cb9ed91b4b8435e5c500a275da5f9f62580e31e80"},
-    {file = "grpcio-1.66.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ba18cfdc09312eb2eea6fa0ce5d2eec3cf345ea78f6528b2eaed6432105e0bd0"},
-    {file = "grpcio-1.66.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:53d4c6706b49e358a2a33345dbe9b6b3bb047cecd7e8c07ba383bd09349bfef8"},
-    {file = "grpcio-1.66.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:643d8d9632a688ae69661e924b862e23c83a3575b24e52917ec5bcc59543d212"},
-    {file = "grpcio-1.66.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba60ae3b465b3e85080ae3bfbc36fd0305ae495ab16fcf8022fc7d7a23aac846"},
-    {file = "grpcio-1.66.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9d5251578767fe44602688c851c2373b5513048ac84c21a0fe946590a8e7933d"},
-    {file = "grpcio-1.66.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5e8140b39f10d7be2263afa2838112de29374c5c740eb0afd99146cb5bdbd990"},
-    {file = "grpcio-1.66.0-cp38-cp38-win32.whl", hash = "sha256:5b15ef1b296c4e78f15f64fc65bf8081f8774480ffcac45642f69d9d753d9c6b"},
-    {file = "grpcio-1.66.0-cp38-cp38-win_amd64.whl", hash = "sha256:c072f90a1f0409f827ae86266984cba65e89c5831a0726b9fc7f4b5fb940b853"},
-    {file = "grpcio-1.66.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:a639d3866bfb5a678b5c0b92cd7ab543033ed8988854290fd86145e71731fd4c"},
-    {file = "grpcio-1.66.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6ed35bf7da3fb3b1949e32bdf47a8b5ffe0aed11722d948933bd068531cd4682"},
-    {file = "grpcio-1.66.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:1c5466222470cb7fbc9cc898af1d48eefd297cb2e2f59af6d4a851c862fa90ac"},
-    {file = "grpcio-1.66.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:921b8f7f25d5300d7c6837a1e0639ef145fbdbfb728e0a5db2dbccc9fc0fd891"},
-    {file = "grpcio-1.66.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3f6feb0dc8456d025e566709f7dd02885add99bedaac50229013069242a1bfd"},
-    {file = "grpcio-1.66.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748452dbd5a047475d5413bdef08b0b9ceb2c0c0e249d4ee905a5fb82c6328dc"},
-    {file = "grpcio-1.66.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:832945e64176520520317b50d64ec7d79924429528d5747669b52d0bf2c7bd78"},
-    {file = "grpcio-1.66.0-cp39-cp39-win32.whl", hash = "sha256:8096a922eb91bc97c839f675c3efa1257c6ef181ae1b25d3fb97f2cae4c57c01"},
-    {file = "grpcio-1.66.0-cp39-cp39-win_amd64.whl", hash = "sha256:375b58892301a5fc6ca7d7ff689c9dc9d00895f5d560604ace9f4f0573013c63"},
-    {file = "grpcio-1.66.0.tar.gz", hash = "sha256:c1ea4c528e7db6660718e4165fd1b5ac24b79a70c870a7bc0b7bdb9babab7c1e"},
+    {file = "grpcio-1.66.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:4877ba180591acdf127afe21ec1c7ff8a5ecf0fe2600f0d3c50e8c4a1cbc6492"},
+    {file = "grpcio-1.66.1-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:3750c5a00bd644c75f4507f77a804d0189d97a107eb1481945a0cf3af3e7a5ac"},
+    {file = "grpcio-1.66.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:a013c5fbb12bfb5f927444b477a26f1080755a931d5d362e6a9a720ca7dbae60"},
+    {file = "grpcio-1.66.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b1b24c23d51a1e8790b25514157d43f0a4dce1ac12b3f0b8e9f66a5e2c4c132f"},
+    {file = "grpcio-1.66.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7ffb8ea674d68de4cac6f57d2498fef477cef582f1fa849e9f844863af50083"},
+    {file = "grpcio-1.66.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:307b1d538140f19ccbd3aed7a93d8f71103c5d525f3c96f8616111614b14bf2a"},
+    {file = "grpcio-1.66.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1c17ebcec157cfb8dd445890a03e20caf6209a5bd4ac5b040ae9dbc59eef091d"},
+    {file = "grpcio-1.66.1-cp310-cp310-win32.whl", hash = "sha256:ef82d361ed5849d34cf09105d00b94b6728d289d6b9235513cb2fcc79f7c432c"},
+    {file = "grpcio-1.66.1-cp310-cp310-win_amd64.whl", hash = "sha256:292a846b92cdcd40ecca46e694997dd6b9be6c4c01a94a0dfb3fcb75d20da858"},
+    {file = "grpcio-1.66.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:c30aeceeaff11cd5ddbc348f37c58bcb96da8d5aa93fed78ab329de5f37a0d7a"},
+    {file = "grpcio-1.66.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8a1e224ce6f740dbb6b24c58f885422deebd7eb724aff0671a847f8951857c26"},
+    {file = "grpcio-1.66.1-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:a66fe4dc35d2330c185cfbb42959f57ad36f257e0cc4557d11d9f0a3f14311df"},
+    {file = "grpcio-1.66.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3ba04659e4fce609de2658fe4dbf7d6ed21987a94460f5f92df7579fd5d0e22"},
+    {file = "grpcio-1.66.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4573608e23f7e091acfbe3e84ac2045680b69751d8d67685ffa193a4429fedb1"},
+    {file = "grpcio-1.66.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:7e06aa1f764ec8265b19d8f00140b8c4b6ca179a6dc67aa9413867c47e1fb04e"},
+    {file = "grpcio-1.66.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3885f037eb11f1cacc41f207b705f38a44b69478086f40608959bf5ad85826dd"},
+    {file = "grpcio-1.66.1-cp311-cp311-win32.whl", hash = "sha256:97ae7edd3f3f91480e48ede5d3e7d431ad6005bfdbd65c1b56913799ec79e791"},
+    {file = "grpcio-1.66.1-cp311-cp311-win_amd64.whl", hash = "sha256:cfd349de4158d797db2bd82d2020554a121674e98fbe6b15328456b3bf2495bb"},
+    {file = "grpcio-1.66.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:a92c4f58c01c77205df6ff999faa008540475c39b835277fb8883b11cada127a"},
+    {file = "grpcio-1.66.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:fdb14bad0835914f325349ed34a51940bc2ad965142eb3090081593c6e347be9"},
+    {file = "grpcio-1.66.1-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:f03a5884c56256e08fd9e262e11b5cfacf1af96e2ce78dc095d2c41ccae2c80d"},
+    {file = "grpcio-1.66.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ca2559692d8e7e245d456877a85ee41525f3ed425aa97eb7a70fc9a79df91a0"},
+    {file = "grpcio-1.66.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84ca1be089fb4446490dd1135828bd42a7c7f8421e74fa581611f7afdf7ab761"},
+    {file = "grpcio-1.66.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:d639c939ad7c440c7b2819a28d559179a4508783f7e5b991166f8d7a34b52815"},
+    {file = "grpcio-1.66.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b9feb4e5ec8dc2d15709f4d5fc367794d69277f5d680baf1910fc9915c633524"},
+    {file = "grpcio-1.66.1-cp312-cp312-win32.whl", hash = "sha256:7101db1bd4cd9b880294dec41a93fcdce465bdbb602cd8dc5bd2d6362b618759"},
+    {file = "grpcio-1.66.1-cp312-cp312-win_amd64.whl", hash = "sha256:b0aa03d240b5539648d996cc60438f128c7f46050989e35b25f5c18286c86734"},
+    {file = "grpcio-1.66.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:ecfe735e7a59e5a98208447293ff8580e9db1e890e232b8b292dc8bd15afc0d2"},
+    {file = "grpcio-1.66.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:4825a3aa5648010842e1c9d35a082187746aa0cdbf1b7a2a930595a94fb10fce"},
+    {file = "grpcio-1.66.1-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:f517fd7259fe823ef3bd21e508b653d5492e706e9f0ef82c16ce3347a8a5620c"},
+    {file = "grpcio-1.66.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f1fe60d0772831d96d263b53d83fb9a3d050a94b0e94b6d004a5ad111faa5b5b"},
+    {file = "grpcio-1.66.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31a049daa428f928f21090403e5d18ea02670e3d5d172581670be006100db9ef"},
+    {file = "grpcio-1.66.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:6f914386e52cbdeb5d2a7ce3bf1fdfacbe9d818dd81b6099a05b741aaf3848bb"},
+    {file = "grpcio-1.66.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bff2096bdba686019fb32d2dde45b95981f0d1490e054400f70fc9a8af34b49d"},
+    {file = "grpcio-1.66.1-cp38-cp38-win32.whl", hash = "sha256:aa8ba945c96e73de29d25331b26f3e416e0c0f621e984a3ebdb2d0d0b596a3b3"},
+    {file = "grpcio-1.66.1-cp38-cp38-win_amd64.whl", hash = "sha256:161d5c535c2bdf61b95080e7f0f017a1dfcb812bf54093e71e5562b16225b4ce"},
+    {file = "grpcio-1.66.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:d0cd7050397b3609ea51727b1811e663ffda8bda39c6a5bb69525ef12414b503"},
+    {file = "grpcio-1.66.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0e6c9b42ded5d02b6b1fea3a25f036a2236eeb75d0579bfd43c0018c88bf0a3e"},
+    {file = "grpcio-1.66.1-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:c9f80f9fad93a8cf71c7f161778ba47fd730d13a343a46258065c4deb4b550c0"},
+    {file = "grpcio-1.66.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5dd67ed9da78e5121efc5c510f0122a972216808d6de70953a740560c572eb44"},
+    {file = "grpcio-1.66.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48b0d92d45ce3be2084b92fb5bae2f64c208fea8ceed7fccf6a7b524d3c4942e"},
+    {file = "grpcio-1.66.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:4d813316d1a752be6f5c4360c49f55b06d4fe212d7df03253dfdae90c8a402bb"},
+    {file = "grpcio-1.66.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9c9bebc6627873ec27a70fc800f6083a13c70b23a5564788754b9ee52c5aef6c"},
+    {file = "grpcio-1.66.1-cp39-cp39-win32.whl", hash = "sha256:30a1c2cf9390c894c90bbc70147f2372130ad189cffef161f0432d0157973f45"},
+    {file = "grpcio-1.66.1-cp39-cp39-win_amd64.whl", hash = "sha256:17663598aadbedc3cacd7bbde432f541c8e07d2496564e22b214b22c7523dac8"},
+    {file = "grpcio-1.66.1.tar.gz", hash = "sha256:35334f9c9745add3e357e3372756fd32d925bd52c41da97f4dfdafbde0bf0ee2"},
 ]
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.66.0)"]
+protobuf = ["grpcio-tools (>=1.66.1)"]
 
 [[package]]
 name = "idna"
@@ -540,12 +540,12 @@ files = [
 
 [[package]]
 name = "nada-dsl"
-version = "0.5.0"
+version = "0.6.0"
 description = "Nillion Nada DSL to create Nillion MPC programs."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "nada_dsl-0.5.0-py3-none-any.whl", hash = "sha256:3ff7b5b825a8a9d9414102d75fa3087b124dc97d5f74d3a33710cfa364babd7b"},
+    {file = "nada_dsl-0.6.0-py3-none-any.whl", hash = "sha256:dd0484953dc3237bf14987840904fe7bc22d4112e6da679c5f550422ddb0d3ad"},
 ]
 
 [package.dependencies]
@@ -555,24 +555,23 @@ richreports = ">=0.2,<1.0"
 sortedcontainers = ">=2.4,<3.0"
 
 [package.extras]
-docs = ["sphinx (>=5,<8)", "sphinx-rtd-theme (>=1.0,<2.1)", "toml (>=0.10.2,<0.11.0)"]
+docs = ["sphinx (>=5,<9)", "sphinx-rtd-theme (>=1.0,<2.1)", "toml (>=0.10.2,<0.11.0)"]
 lint = ["pylint (>=2.17,<3.3)"]
 test = ["pytest (>=7.4,<9.0)", "pytest-cov (>=4,<6)"]
 
 [[package]]
 name = "nillion-python-helpers"
-version = "0.2.6"
+version = "0.2.3"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "nillion_python_helpers-0.2.6-py3-none-any.whl", hash = "sha256:e3d61a7d3f615064277e726ac82b858d2195f88d9bde8dfd392d4d8478aae599"},
-    {file = "nillion_python_helpers-0.2.6.tar.gz", hash = "sha256:e3a31b2823511a2752bc0c62cfaf6964786ef13b765de4492c45266093aa52c1"},
+    {file = "nillion_python_helpers-0.2.3-py3-none-any.whl", hash = "sha256:e047e16bb456923d22409a84b7019af5370e0576437d91fe88fb839105da3f2a"},
+    {file = "nillion_python_helpers-0.2.3.tar.gz", hash = "sha256:fcc1293f0c0567518d4e5cf0a91613587ee779839618e9c7e73b6afa8792a8ee"},
 ]
 
 [package.dependencies]
 cosmpy = ">=0.9.2,<0.10.0"
-py-nillion-client = ">=0.5.0,<0.6.0"
 pytest-asyncio = ">=0.23.7,<0.24.0"
 python-dotenv = "1.0.0"
 
@@ -714,15 +713,15 @@ files = [
 
 [[package]]
 name = "py-nillion-client"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python client for Nillion network and utilities."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "py_nillion_client-0.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:cda0c4c6a5ee364fd58003628a6247d0110d7f7d3691d1005bfc77d828c97932"},
-    {file = "py_nillion_client-0.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:3e185edff4c0ebedd008da1703e05bfba4da05bd67714d25d8aafcb835038803"},
-    {file = "py_nillion_client-0.5.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d662cdc9cc637f0f444b7840715dd46c723c52b5935200839e96f3575e96ed74"},
-    {file = "py_nillion_client-0.5.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d0d47ff6547a0d0390f35f195e73fedfbccf6e054b07016f2f375634daca7a1"},
+    {file = "py_nillion_client-0.6.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8921284ceb9ae6e01c509ca1d9802d5fafdbc2906a4b9afac29551f5ee976d62"},
+    {file = "py_nillion_client-0.6.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e8141f3010c4914ce648b53c8b798f8d8e79370b29cee13cc9dcc642f9e45487"},
+    {file = "py_nillion_client-0.6.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:240d5bf784c6007eed8a082c532f11ba92af8191c81cb611ae1964e7ef89fa1a"},
+    {file = "py_nillion_client-0.6.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a6ddc4c1170895ba140691c7cab3e87e3ec7cd2836e851a6458fc2a670bf7e9"},
 ]
 
 [package.dependencies]
@@ -1220,4 +1219,4 @@ linter = ["black", "isort"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "92f8a245e0fad433ed278cab5e8168167cba957092263d09964e631b10c9ba60"
+content-hash = "052a7c1e3d227d3ad1f59e7f84f48e7633ae68abc093b6befa996084546ff64a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nada-numpy"
-version = "0.4.2"
+version = "0.5.0"
 description = "Nada-Numpy is a Python library designed for algebraic operations on NumPy-like array objects on top of Nada DSL and Nillion Network."
 authors = ["José Cabrero-Holgueras <jose.cabrero@nillion.com>"]
 readme = "README.md"
@@ -8,8 +8,8 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 numpy = "^1.26.4"
-nada-dsl = "^0.5.0"
-py-nillion-client = "^0.5.0"
+nada-dsl = "^0.6.0"
+py-nillion-client = "^0.6.0"
 nillion-python-helpers = "^0.2.3"
 black = {version="24.8.0", optional=true}
 isort = {version="^5.13.2", optional=true}

--- a/tests/nada-tests/src/array_attributes.py
+++ b/tests/nada-tests/src/array_attributes.py
@@ -14,6 +14,8 @@ def nada_main():
     b = na.NadaArray(np.array([]))
     c = na.NadaArray(np.array([na.rational(1.5)]))
 
+    a += Integer(0)
+
     assert not a.empty
     assert b.empty
     assert not c.empty

--- a/tests/nada-tests/src/base.py
+++ b/tests/nada-tests/src/base.py
@@ -8,4 +8,6 @@ def nada_main():
 
     a = na.array([3], parties[0], "A", SecretInteger)
 
+    a += Integer(0)
+
     return a.output(parties[1], "my_output")

--- a/tests/nada-tests/src/functional_operations.py
+++ b/tests/nada-tests/src/functional_operations.py
@@ -10,6 +10,9 @@ def nada_main():
     a = na.array([3], parties[0], "A", SecretInteger)
     b = na.array([3], parties[0], "B", na.SecretRational)
 
+    a += Integer(0)
+    b += na.rational(0)
+
     # Test all for a native NadaType
     _ = na.sum(a)
     _ = na.compress(a, [True, True, False], axis=0)

--- a/tests/nada-tests/src/hstack.py
+++ b/tests/nada-tests/src/hstack.py
@@ -9,4 +9,8 @@ def nada_main():
     a = na.array([3], parties[0], "A", SecretInteger)
     b = na.array([3], parties[1], "B", SecretInteger)
 
-    return a.hstack(b).output(parties[2], "my_output")
+    c = a.hstack(b)
+
+    c += Integer(0)
+
+    return c.output(parties[2], "my_output")

--- a/tests/nada-tests/src/random_array.py
+++ b/tests/nada-tests/src/random_array.py
@@ -20,6 +20,8 @@ def nada_main():
         assert random_arr_2.shape == (4, 2, 3), random_arr_2.shape
         assert isinstance(random_arr_2.item(0), supported_type)
 
+    a += Integer(0)
+
     with pytest.raises(Exception):
         na.random((1,), PublicInteger)
 

--- a/tests/nada-tests/src/rational_arithmetic.py
+++ b/tests/nada-tests/src/rational_arithmetic.py
@@ -24,8 +24,6 @@ def nada_main():
     out_9 = b**0  # 1 -> 65536
     out_10 = a ** (-3)  # 0.03051757812499999 -> 2000
 
-    assert a == a**1, a**1
-
     return [
         Output(out_0.value, "my_output_0", parties[0]),
         Output(out_1.value, "my_output_1", parties[0]),

--- a/tests/nada-tests/src/type_guardrails.py
+++ b/tests/nada-tests/src/type_guardrails.py
@@ -12,6 +12,10 @@ def nada_main():
     b = na.array([3], parties[0], "B", SecretInteger)
     c = na.array([3], parties[0], "C", PublicInteger)
 
+    a += na.rational(0)
+    b += Integer(0)
+    c += Integer(0)
+
     # Mixed secretrational - secretinteger
     with pytest.raises(TypeError):
         na.NadaArray(np.array([a[0], b[0]]))

--- a/tests/nada-tests/src/vstack.py
+++ b/tests/nada-tests/src/vstack.py
@@ -9,4 +9,8 @@ def nada_main():
     a = na.array([3], parties[0], "A", SecretInteger)
     b = na.array([3], parties[1], "B", SecretInteger)
 
-    return a.vstack(b).output(parties[2], "my_output")
+    c = a.vstack(b)
+
+    c += Integer(0)
+
+    return c.output(parties[2], "my_output")

--- a/tests/nada-tests/tests/array_attributes.yaml
+++ b/tests/nada-tests/tests/array_attributes.yaml
@@ -1,15 +1,9 @@
 program: array_attributes
 inputs:
-  A_1:
-    SecretInteger: '3'
-  A_2:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
+  A_1: 3
+  A_2: 3
+  A_0: 3
 expected_outputs:
-  my_output_0:
-    SecretInteger: '3'
-  my_output_1:
-    SecretInteger: '3'
-  my_output_2:
-    SecretInteger: '3'
+  my_output_0: 3
+  my_output_1: 3
+  my_output_2: 3

--- a/tests/nada-tests/tests/array_comparison.yaml
+++ b/tests/nada-tests/tests/array_comparison.yaml
@@ -1,99 +1,45 @@
----
 program: array_comparison
 inputs:
-  A_0_0:
-    SecretInteger: "1"
-  A_0_1:
-    SecretInteger: "100"
-  A_0_2:
-    SecretInteger: "0"
-  B_0_0:
-    SecretInteger: "8"
-  B_0_1:
-    SecretInteger: "101"
-  B_0_2:
-    SecretInteger: "0"
+  A_0_0: 1
+  A_0_1: 100
+  A_0_2: 0
+  B_0_0: 8
+  B_0_1: 101
+  B_0_2: 0
 expected_outputs:
-  my_output_1_0_0:
-    SecretBoolean: false
-  my_output_1_0_1:
-    SecretBoolean: false
-  my_output_1_0_2:
-    SecretBoolean: true
-
-  my_output_2_0_0:
-    SecretBoolean: true
-  my_output_2_0_1:
-    SecretBoolean: false
-  my_output_2_0_2:
-    SecretBoolean: false
-
-  my_output_3_0_0:
-    SecretBoolean: true
-  my_output_3_0_1:
-    SecretBoolean: true
-  my_output_3_0_2:
-    SecretBoolean: false
-
-  my_output_4_0_0:
-    SecretBoolean: false
-  my_output_4_0_1:
-    SecretBoolean: true
-  my_output_4_0_2:
-    SecretBoolean: true
-
-  my_output_5_0_0:
-    SecretBoolean: true
-  my_output_5_0_1:
-    SecretBoolean: true
-  my_output_5_0_2:
-    SecretBoolean: false
-
-  my_output_6_0_0:
-    SecretBoolean: false
-  my_output_6_0_1:
-    SecretBoolean: false
-  my_output_6_0_2:
-    SecretBoolean: true
-
-  my_output_7_0_0:
-    SecretBoolean: true
-  my_output_7_0_1:
-    SecretBoolean: true
-  my_output_7_0_2:
-    SecretBoolean: true
-
-  my_output_8_0_0:
-    SecretBoolean: true
-  my_output_8_0_1:
-    SecretBoolean: false
-  my_output_8_0_2:
-    SecretBoolean: true
-
-  my_output_9_0_0:
-    SecretBoolean: false
-  my_output_9_0_1:
-    SecretBoolean: false
-  my_output_9_0_2:
-    SecretBoolean: false
-
-  my_output_10_0_0:
-    SecretBoolean: false
-  my_output_10_0_1:
-    SecretBoolean: true
-  my_output_10_0_2:
-    SecretBoolean: false
-
-  my_output_11_0_0:
-    SecretBoolean: false
-  my_output_11_0_1:
-    SecretBoolean: false
-  my_output_11_0_2:
-    SecretBoolean: true
-
-  my_output_12_0_0:
-    SecretBoolean: true
-  my_output_12_0_1:
-    SecretBoolean: true
-  my_output_12_0_2:
-    SecretBoolean: false
+  my_output_1_0_0: false
+  my_output_1_0_1: false
+  my_output_1_0_2: true
+  my_output_2_0_0: true
+  my_output_2_0_1: false
+  my_output_2_0_2: false
+  my_output_3_0_0: true
+  my_output_3_0_1: true
+  my_output_3_0_2: false
+  my_output_4_0_0: false
+  my_output_4_0_1: true
+  my_output_4_0_2: true
+  my_output_5_0_0: true
+  my_output_5_0_1: true
+  my_output_5_0_2: false
+  my_output_6_0_0: false
+  my_output_6_0_1: false
+  my_output_6_0_2: true
+  my_output_7_0_0: true
+  my_output_7_0_1: true
+  my_output_7_0_2: true
+  my_output_8_0_0: true
+  my_output_8_0_1: false
+  my_output_8_0_2: true
+  my_output_9_0_0: false
+  my_output_9_0_1: false
+  my_output_9_0_2: false
+  my_output_10_0_0: false
+  my_output_10_0_1: true
+  my_output_10_0_2: false
+  my_output_11_0_0: false
+  my_output_11_0_1: false
+  my_output_11_0_2: true
+  my_output_12_0_0: true
+  my_output_12_0_1: true
+  my_output_12_0_2: false

--- a/tests/nada-tests/tests/array_statistics.yaml
+++ b/tests/nada-tests/tests/array_statistics.yaml
@@ -1,51 +1,27 @@
 program: array_statistics
 inputs:
-  A_0_0:
-    SecretInteger: '1'
-  A_0_1:
-    SecretInteger: '2'
-  A_1_0:
-    SecretInteger: '4'
-  A_1_1:
-    SecretInteger: '5'
-  A_2_0:
-    SecretInteger: '4'
-  A_2_1:
-    SecretInteger: '5'
-  B_0_0:
-    SecretInteger: '1'
-  B_0_1:
-    SecretInteger: '2'
-  B_1_0:
-    SecretInteger: '4'
-  B_1_1:
-    SecretInteger: '5'
-  B_2_0:
-    SecretInteger: '4'
-  B_2_1:
-    SecretInteger: '5'
+  A_0_0: 1
+  A_0_1: 2
+  A_1_0: 4
+  A_1_1: 5
+  A_2_0: 4
+  A_2_1: 5
+  B_0_0: 1
+  B_0_1: 2
+  B_1_0: 4
+  B_1_1: 5
+  B_2_0: 4
+  B_2_1: 5
 expected_outputs:
-  a_mean_arr_1:
-    SecretInteger: '4'
-  b_mean_arr_0:
-    SecretInteger: '3'
-  b_sum:
-    SecretInteger: '21'
-  b_mean:
-    SecretInteger: '3'
-  a_mean_arr_0:
-    SecretInteger: '3'
-  b_mean_arr_1:
-    SecretInteger: '4'
-  b_sum_arr_0:
-    SecretInteger: '9'
-  a_sum:
-    SecretInteger: '21'
-  a_sum_arr_0:
-    SecretInteger: '9'
-  b_sum_arr_1:
-    SecretInteger: '12'
-  a_mean:
-    SecretInteger: '3'
-  a_sum_arr_1:
-    SecretInteger: '12'
+  a_mean_arr_1: 4
+  b_mean_arr_0: 3
+  b_sum: 21
+  b_mean: 3
+  a_mean_arr_0: 3
+  b_mean_arr_1: 4
+  b_sum_arr_0: 9
+  a_sum: 21
+  a_sum_arr_0: 9
+  b_sum_arr_1: 12
+  a_mean: 3
+  a_sum_arr_1: 12

--- a/tests/nada-tests/tests/base.yaml
+++ b/tests/nada-tests/tests/base.yaml
@@ -1,15 +1,9 @@
 program: base
 inputs:
-  A_1:
-    SecretInteger: '3'
-  A_2:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
+  A_1: 3
+  A_2: 3
+  A_0: 3
 expected_outputs:
-  my_output_0:
-    SecretInteger: '3'
-  my_output_1:
-    SecretInteger: '3'
-  my_output_2:
-    SecretInteger: '3'
+  my_output_0: 3
+  my_output_1: 3
+  my_output_2: 3

--- a/tests/nada-tests/tests/broadcasting_div.yaml
+++ b/tests/nada-tests/tests/broadcasting_div.yaml
@@ -1,30 +1,15 @@
----
 program: broadcasting_div
 inputs:
-  A_0:
-    SecretInteger: "10"
-  A_1:
-    SecretInteger: "8"
-  A_2:
-    SecretInteger: "4"
-  B_0:
-    SecretInteger: "10"
-  B_1:
-    SecretInteger: "4"
-  B_2:
-    SecretInteger: "2"
+  A_0: 10
+  A_1: 8
+  A_2: 4
+  B_0: 10
+  B_1: 4
+  B_2: 2
 expected_outputs:
-  my_output_1_0:
-    SecretInteger: "1"
-  my_output_1_1:
-    SecretInteger: "2"
-  my_output_1_2:
-    SecretInteger: "2"
-  my_output_2_0:
-    SecretInteger: "5"
-  my_output_2_1:
-    SecretInteger: "4"
-  my_output_2_2:
-    SecretInteger: "2"
-
-
+  my_output_1_0: 1
+  my_output_1_1: 2
+  my_output_1_2: 2
+  my_output_2_0: 5
+  my_output_2_1: 4
+  my_output_2_2: 2

--- a/tests/nada-tests/tests/broadcasting_mul.yaml
+++ b/tests/nada-tests/tests/broadcasting_mul.yaml
@@ -1,30 +1,15 @@
----
 program: broadcasting_mul
 inputs:
-  A_0:
-    SecretInteger: "10"
-  A_1:
-    SecretInteger: "8"
-  A_2:
-    SecretInteger: "4"
-  B_0:
-    SecretInteger: "10"
-  B_1:
-    SecretInteger: "4"
-  B_2:
-    SecretInteger: "2"
+  A_0: 10
+  A_1: 8
+  A_2: 4
+  B_0: 10
+  B_1: 4
+  B_2: 2
 expected_outputs:
-  my_output_1_0:
-    SecretInteger: "100"
-  my_output_1_1:
-    SecretInteger: "32"
-  my_output_1_2:
-    SecretInteger: "8"
-  my_output_2_0:
-    SecretInteger: "20"
-  my_output_2_1:
-    SecretInteger: "16"
-  my_output_2_2:
-    SecretInteger: "8"
-
-
+  my_output_1_0: 100
+  my_output_1_1: 32
+  my_output_1_2: 8
+  my_output_2_0: 20
+  my_output_2_1: 16
+  my_output_2_2: 8

--- a/tests/nada-tests/tests/broadcasting_rationals.yaml
+++ b/tests/nada-tests/tests/broadcasting_rationals.yaml
@@ -1,59 +1,31 @@
 program: broadcasting_rationals
 inputs:
-  X_2:
-    SecretInteger: '196608'
-  y:
-    SecretInteger: '262144'
-  X_1:
-    SecretInteger: '131072'
-  X_0:
-    SecretInteger: '65536'
+  X_2: 196608
+  y: 262144
+  X_1: 131072
+  X_0: 65536
 expected_outputs:
-  my_output_a_0:
-    SecretInteger: '327680'
-  my_output_a_1:
-    SecretInteger: '393216'
-  my_output_a_2:
-    SecretInteger: '458752'
-  my_output_b_0:
-    SecretInteger: '327680'
-  my_output_b_1:
-    SecretInteger: '393216'
-  my_output_b_2:
-    SecretInteger: '458752'
-  my_output_c_0:
-    SecretInteger: '-196608'
-  my_output_c_1:
-    SecretInteger: '-131072'
-  my_output_c_2:
-    SecretInteger: '-65536'
-  my_output_d_0:
-    SecretInteger: '196608'
-  my_output_d_1:
-    SecretInteger: '131072'
-  my_output_d_2:
-    SecretInteger: '65536'
-  my_output_e_0:
-    SecretInteger: '262144'
-  my_output_e_1:
-    SecretInteger: '524288'
-  my_output_e_2:
-    SecretInteger: '786432'
-  my_output_f_0:
-    SecretInteger: '262144'
-  my_output_f_1:
-    SecretInteger: '524288'
-  my_output_f_2:
-    SecretInteger: '786432'
-  my_output_g_0:
-    SecretInteger: '16384'
-  my_output_g_1:
-    SecretInteger: '32768'
-  my_output_g_2:
-    SecretInteger: '49152'
-  my_output_h_0:
-    SecretInteger: '262144'
-  my_output_h_1:
-    SecretInteger: '131072'
-  my_output_h_2:
-    SecretInteger: '87381'
+  my_output_a_0: 327680
+  my_output_a_1: 393216
+  my_output_a_2: 458752
+  my_output_b_0: 327680
+  my_output_b_1: 393216
+  my_output_b_2: 458752
+  my_output_c_0: -196608
+  my_output_c_1: -131072
+  my_output_c_2: -65536
+  my_output_d_0: 196608
+  my_output_d_1: 131072
+  my_output_d_2: 65536
+  my_output_e_0: 262144
+  my_output_e_1: 524288
+  my_output_e_2: 786432
+  my_output_f_0: 262144
+  my_output_f_1: 524288
+  my_output_f_2: 786432
+  my_output_g_0: 16384
+  my_output_g_1: 32768
+  my_output_g_2: 49152
+  my_output_h_0: 262144
+  my_output_h_1: 131072
+  my_output_h_2: 87381

--- a/tests/nada-tests/tests/broadcasting_sub.yaml
+++ b/tests/nada-tests/tests/broadcasting_sub.yaml
@@ -1,30 +1,15 @@
----
 program: broadcasting_sub
 inputs:
-  A_0:
-    SecretInteger: "10"
-  A_1:
-    SecretInteger: "8"
-  A_2:
-    SecretInteger: "4"
-  B_0:
-    SecretInteger: "10"
-  B_1:
-    SecretInteger: "4"
-  B_2:
-    SecretInteger: "2"
+  A_0: 10
+  A_1: 8
+  A_2: 4
+  B_0: 10
+  B_1: 4
+  B_2: 2
 expected_outputs:
-  my_output_1_0:
-    SecretInteger: "0"
-  my_output_1_1:
-    SecretInteger: "4"
-  my_output_1_2:
-    SecretInteger: "2"
-  my_output_2_0:
-    SecretInteger: "8"
-  my_output_2_1:
-    SecretInteger: "6"
-  my_output_2_2:
-    SecretInteger: "2"
-
-
+  my_output_1_0: 0
+  my_output_1_1: 4
+  my_output_1_2: 2
+  my_output_2_0: 8
+  my_output_2_1: 6
+  my_output_2_2: 2

--- a/tests/nada-tests/tests/broadcasting_sum.yaml
+++ b/tests/nada-tests/tests/broadcasting_sum.yaml
@@ -1,30 +1,15 @@
----
 program: broadcasting_sum
 inputs:
-  A_0:
-    SecretInteger: "10"
-  A_1:
-    SecretInteger: "8"
-  A_2:
-    SecretInteger: "4"
-  B_0:
-    SecretInteger: "10"
-  B_1:
-    SecretInteger: "4"
-  B_2:
-    SecretInteger: "2"
+  A_0: 10
+  A_1: 8
+  A_2: 4
+  B_0: 10
+  B_1: 4
+  B_2: 2
 expected_outputs:
-  my_output_1_0:
-    SecretInteger: "20"
-  my_output_1_1:
-    SecretInteger: "12"
-  my_output_1_2:
-    SecretInteger: "6"
-  my_output_2_0:
-    SecretInteger: "12"
-  my_output_2_1:
-    SecretInteger: "10"
-  my_output_2_2:
-    SecretInteger: "6"
-
-
+  my_output_1_0: 20
+  my_output_1_1: 12
+  my_output_1_2: 6
+  my_output_2_0: 12
+  my_output_2_1: 10
+  my_output_2_2: 6

--- a/tests/nada-tests/tests/broadcasting_vec.yaml
+++ b/tests/nada-tests/tests/broadcasting_vec.yaml
@@ -1,111 +1,57 @@
 program: broadcasting_vec
 inputs:
-  A_0_0_0:
-    SecretInteger: '3'
-  A_0_1_0:
-    SecretInteger: '3'
-  A_0_0_2:
-    SecretInteger: '3'
-  A_2_1_1:
-    SecretInteger: '3'
-  A_2_2_1:
-    SecretInteger: '3'
-  A_1_1_2:
-    SecretInteger: '3'
-  A_1_2_0:
-    SecretInteger: '3'
-  A_0_2_0:
-    SecretInteger: '3'
-  A_1_1_0:
-    SecretInteger: '3'
-  A_1_0_1:
-    SecretInteger: '3'
-  A_0_0_1:
-    SecretInteger: '3'
-  A_0_1_2:
-    SecretInteger: '3'
-  A_1_2_1:
-    SecretInteger: '3'
-  A_2_1_0:
-    SecretInteger: '3'
-  A_0_2_1:
-    SecretInteger: '3'
-  A_2_0_0:
-    SecretInteger: '3'
-  A_2_1_2:
-    SecretInteger: '3'
-  A_1_1_1:
-    SecretInteger: '3'
-  A_0_2_2:
-    SecretInteger: '3'
-  A_1_0_0:
-    SecretInteger: '3'
-  A_1_0_2:
-    SecretInteger: '3'
-  A_2_0_1:
-    SecretInteger: '3'
-  A_2_0_2:
-    SecretInteger: '3'
-  A_2_2_0:
-    SecretInteger: '3'
-  A_2_2_2:
-    SecretInteger: '3'
-  A_1_2_2:
-    SecretInteger: '3'
-  A_0_1_1:
-    SecretInteger: '3'
+  A_0_0_0: 3
+  A_0_1_0: 3
+  A_0_0_2: 3
+  A_2_1_1: 3
+  A_2_2_1: 3
+  A_1_1_2: 3
+  A_1_2_0: 3
+  A_0_2_0: 3
+  A_1_1_0: 3
+  A_1_0_1: 3
+  A_0_0_1: 3
+  A_0_1_2: 3
+  A_1_2_1: 3
+  A_2_1_0: 3
+  A_0_2_1: 3
+  A_2_0_0: 3
+  A_2_1_2: 3
+  A_1_1_1: 3
+  A_0_2_2: 3
+  A_1_0_0: 3
+  A_1_0_2: 3
+  A_2_0_1: 3
+  A_2_0_2: 3
+  A_2_2_0: 3
+  A_2_2_2: 3
+  A_1_2_2: 3
+  A_0_1_1: 3
 expected_outputs:
-  my_output_1_0_2:
-    SecretInteger: '3'
-  my_output_0_1_2:
-    SecretInteger: '3'
-  my_output_0_2_2:
-    SecretInteger: '3'
-  my_output_1_2_0:
-    SecretInteger: '3'
-  my_output_2_1_1:
-    SecretInteger: '3'
-  my_output_0_0_0:
-    SecretInteger: '3'
-  my_output_1_0_1:
-    SecretInteger: '3'
-  my_output_0_1_1:
-    SecretInteger: '3'
-  my_output_1_1_0:
-    SecretInteger: '3'
-  my_output_1_2_2:
-    SecretInteger: '3'
-  my_output_2_1_2:
-    SecretInteger: '3'
-  my_output_2_2_2:
-    SecretInteger: '3'
-  my_output_1_1_2:
-    SecretInteger: '3'
-  my_output_0_2_0:
-    SecretInteger: '3'
-  my_output_1_0_0:
-    SecretInteger: '3'
-  my_output_0_1_0:
-    SecretInteger: '3'
-  my_output_1_2_1:
-    SecretInteger: '3'
-  my_output_2_0_1:
-    SecretInteger: '3'
-  my_output_1_1_1:
-    SecretInteger: '3'
-  my_output_2_1_0:
-    SecretInteger: '3'
-  my_output_2_2_1:
-    SecretInteger: '3'
-  my_output_0_0_1:
-    SecretInteger: '3'
-  my_output_2_2_0:
-    SecretInteger: '3'
-  my_output_0_0_2:
-    SecretInteger: '3'
-  my_output_2_0_2:
-    SecretInteger: '3'
-  my_output_2_0_0:
-    SecretInteger: '3'
-  my_output_0_2_1:
-    SecretInteger: '3'
+  my_output_1_0_2: 3
+  my_output_0_1_2: 3
+  my_output_0_2_2: 3
+  my_output_1_2_0: 3
+  my_output_2_1_1: 3
+  my_output_0_0_0: 3
+  my_output_1_0_1: 3
+  my_output_0_1_1: 3
+  my_output_1_1_0: 3
+  my_output_1_2_2: 3
+  my_output_2_1_2: 3
+  my_output_2_2_2: 3
+  my_output_1_1_2: 3
+  my_output_0_2_0: 3
+  my_output_1_0_0: 3
+  my_output_0_1_0: 3
+  my_output_1_2_1: 3
+  my_output_2_0_1: 3
+  my_output_1_1_1: 3
+  my_output_2_1_0: 3
+  my_output_2_2_1: 3
+  my_output_0_0_1: 3
+  my_output_2_2_0: 3
+  my_output_0_0_2: 3
+  my_output_2_0_2: 3
+  my_output_2_0_0: 3
+  my_output_0_2_1: 3

--- a/tests/nada-tests/tests/chained_rational_operations.yaml
+++ b/tests/nada-tests/tests/chained_rational_operations.yaml
@@ -1,9 +1,6 @@
 program: chained_rational_operations
 inputs:
-  my_input_0:
-    SecretInteger: '209715'
-  my_input_1:
-    SecretInteger: '294912'
+  my_input_0: 209715
+  my_input_1: 294912
 expected_outputs:
-  my_output_0:
-    SecretInteger: '294912'
+  my_output_0: 294912

--- a/tests/nada-tests/tests/dot_product.yaml
+++ b/tests/nada-tests/tests/dot_product.yaml
@@ -1,17 +1,10 @@
 program: dot_product
 inputs:
-  A_0:
-    SecretInteger: '3'
-  A_1:
-    SecretInteger: '3'
-  A_2:
-    SecretInteger: '3'
-  B_0:
-    SecretInteger: '3'
-  B_1:
-    SecretInteger: '3'
-  B_2:
-    SecretInteger: '3'
+  A_0: 3
+  A_1: 3
+  A_2: 3
+  B_0: 3
+  B_1: 3
+  B_2: 3
 expected_outputs:
-  my_output:
-    SecretInteger: '27'
+  my_output: 27

--- a/tests/nada-tests/tests/dot_product_rational.yaml
+++ b/tests/nada-tests/tests/dot_product_rational.yaml
@@ -1,23 +1,13 @@
 program: dot_product_rational
 inputs:
-  A_0:
-    SecretInteger: '65536'
-  A_1:
-    SecretInteger: '131072'
-  A_2:
-    SecretInteger: '196608'
-  B_0:
-    SecretInteger: '65536'
-  B_1:
-    SecretInteger: '131072'
-  B_2:
-    SecretInteger: '196608'
+  A_0: 65536
+  A_1: 131072
+  A_2: 196608
+  B_0: 65536
+  B_1: 131072
+  B_2: 196608
 expected_outputs:
-  my_output_a:
-    SecretInteger: '917504'
-  my_output_b:
-    SecretInteger: '917504'
-  my_output_c:
-    SecretInteger: '393216'
-  my_output_d:
-    SecretInteger: '393216'
+  my_output_a: 917504
+  my_output_b: 917504
+  my_output_c: 393216
+  my_output_d: 393216

--- a/tests/nada-tests/tests/functional_operations.yaml
+++ b/tests/nada-tests/tests/functional_operations.yaml
@@ -1,23 +1,13 @@
 program: functional_operations
 inputs:
-  A_1:
-    SecretInteger: '3'
-  B_0:
-    SecretInteger: '3'
-  B_1:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
+  A_1: 3
+  B_0: 3
+  B_1: 3
+  A_0: 3
 expected_outputs:
-  my_output_A_0_0:
-    SecretInteger: '3'
-  my_output_B_0_1:
-    SecretInteger: '3'
-  my_output_A_0_2:
-    Integer: '20'
-  my_output_B_0_2:
-    Integer: '20'
-  my_output_A_0_1:
-    SecretInteger: '3'
-  my_output_B_0_0:
-    SecretInteger: '3'
+  my_output_A_0_0: 3
+  my_output_B_0_1: 3
+  my_output_A_0_2: 20
+  my_output_B_0_2: 20
+  my_output_A_0_1: 3
+  my_output_B_0_0: 3

--- a/tests/nada-tests/tests/fxpmath_arrays.yaml
+++ b/tests/nada-tests/tests/fxpmath_arrays.yaml
@@ -1,95 +1,48 @@
----
 program: fxpmath_arrays
 inputs:
-  my_input_0:
-    SecretInteger: "3"
+  my_input_0: 3
 expected_outputs:
-  result_sig_0:
-    SecretInteger: "32711"
-  result_sqrt_1:
-    Integer: "80265"
-  result_sig_motz_1:
-    Integer: "53477"
-  result_silu_0:
-    SecretInteger: "1"
-  result_gelu_0:
-    SecretInteger: "1"
-  result_tan_1:
-    Integer: "888645"
-  result_tanh_1:
-    Integer: "59434"
-  result_tan_0:
-    SecretInteger: "0"
-  result_exp_0:
-    SecretInteger: "65536"
-  result_sig_1:
-    Integer: "53644"
-  result_silu_motz_1:
-    Integer: "80215"
-  result_gelu_motz_1:
-    Integer: "91629"
-  result_sig_che_1:
-    Integer: "53580"
-  result_log_0:
-    SecretInteger: "-614828"
-  result_sqrt_0:
-    SecretInteger: "45"
-  result_silu_che_0:
-    SecretInteger: "1"
-  result_rec_NR_1:
-    Integer: "43692"
-  result_tanh_che_1:
-    Integer: "65536"
-  result_gelu_motz_0:
-    SecretInteger: "103"
-  result_exp_1:
-    Integer: "292119"
-  result_isqrt_1:
-    Integer: "53510"
-  result_cos_1:
-    Integer: "4846"
-  result_tanh_motz_1:
-    Integer: "59394"
-  result_cos_0:
-    SecretInteger: "65536"
-  result_sig_che_0:
-    SecretInteger: "32768"
-  result_rec_log_0:
-    SecretInteger: "65040192"
-  result_sig_motz_0:
-    SecretInteger: "32686"
-  result_log_1:
-    Integer: "26359"
-  result_tanh_0:
-    SecretInteger: "-114"
-  result_sin_1:
-    Integer: "65710"
-  result_gelu_1:
-    Integer: "91839"
-  result_silu_che_1:
-    Integer: "80370"
-  result_tanh_motz_0:
-    SecretInteger: "-160"
-  result_tanh_che_0:
-    SecretInteger: "2"
-  result_rec_NR_0:
-    SecretInteger: "451510139"
-  result_rec_log_1:
-    Integer: "34575"
-  result_silu_1:
-    Integer: "80466"
-  result_isqrt_0:
-    SecretInteger: "989647"
-  result_silu_motz_0:
-    SecretInteger: "1"
-  result_sin_0:
-    SecretInteger: "0"
-  result_sign_1:
-    Integer: "65536"
-  result_sign_0:
-    SecretInteger: "65536"
-  result_abs_1:
-    Integer: "98304"
-  result_abs_0:
-    SecretInteger: "3"
-
+  result_sig_0: 32711
+  result_sqrt_1: 80265
+  result_sig_motz_1: 53477
+  result_silu_0: 1
+  result_gelu_0: 1
+  result_tan_1: 888645
+  result_tanh_1: 59434
+  result_tan_0: 0
+  result_exp_0: 65536
+  result_sig_1: 53644
+  result_silu_motz_1: 80215
+  result_gelu_motz_1: 91629
+  result_sig_che_1: 53580
+  result_log_0: -614828
+  result_sqrt_0: 45
+  result_silu_che_0: 1
+  result_rec_NR_1: 43692
+  result_tanh_che_1: 65536
+  result_gelu_motz_0: 103
+  result_exp_1: 292119
+  result_isqrt_1: 53510
+  result_cos_1: 4846
+  result_tanh_motz_1: 59394
+  result_cos_0: 65536
+  result_sig_che_0: 32768
+  result_rec_log_0: 65040192
+  result_sig_motz_0: 32686
+  result_log_1: 26359
+  result_tanh_0: -114
+  result_sin_1: 65710
+  result_gelu_1: 91839
+  result_silu_che_1: 80370
+  result_tanh_motz_0: -160
+  result_tanh_che_0: 2
+  result_rec_NR_0: 451510139
+  result_rec_log_1: 34575
+  result_silu_1: 80466
+  result_isqrt_0: 989647
+  result_silu_motz_0: 1
+  result_sin_0: 0
+  result_sign_1: 65536
+  result_sign_0: 65536
+  result_abs_1: 98304
+  result_abs_0: 3

--- a/tests/nada-tests/tests/fxpmath_funcs.yaml
+++ b/tests/nada-tests/tests/fxpmath_funcs.yaml
@@ -1,44 +1,24 @@
----
 program: fxpmath_funcs
 inputs:
-  my_input_0:
-    SecretInteger: "65536"
+  my_input_0: 65536
 expected_outputs:
-  result_gelu:
-    SecretInteger: "-13"
-  result_cos:
-    SecretInteger: "-32566"
-  result_isqrt:
-    SecretInteger: "-2341"
-  result_gelu_motz:
-    SecretInteger: "0"
-  result_silu:
-    SecretInteger: "655340"
-  result_sin:
-    SecretInteger: "57328"
-  result_tanh_che:
-    SecretInteger: "19089"
-  result_tanh_motz:
-    SecretInteger: "24917"
-  result_silu_che:
-    SecretInteger: "0"
-  result_sig_motz:
-    SecretInteger: "65536"
-  result_tanh:
-    SecretInteger: "56624"
-  result_rec_log:
-    SecretInteger: "15552"
-  result_sig_che:
-    SecretInteger: "31130"
-  result_sig:
-    SecretInteger: "34401"
-  result_tan:
-    SecretInteger: "-922765"
-  result_sqrt:
-    SecretInteger: "262128"
-  result_log:
-    SecretInteger: "298843"
-  result_exp:
-    SecretInteger: "480249"
-  result_rec_NR:
-    SecretInteger: "32768"
+  result_gelu: -13
+  result_cos: -32566
+  result_isqrt: -2341
+  result_gelu_motz: 0
+  result_silu: 655340
+  result_sin: 57328
+  result_tanh_che: 19089
+  result_tanh_motz: 24917
+  result_silu_che: 0
+  result_sig_motz: 65536
+  result_tanh: 56624
+  result_rec_log: 15552
+  result_sig_che: 31130
+  result_sig: 34401
+  result_tan: -922765
+  result_sqrt: 262128
+  result_log: 298843
+  result_exp: 480249
+  result_rec_NR: 32768
+  result_silu_motz: 0

--- a/tests/nada-tests/tests/fxpmath_methods.yaml
+++ b/tests/nada-tests/tests/fxpmath_methods.yaml
@@ -1,44 +1,24 @@
----
 program: fxpmath_methods
 inputs:
-  my_input_0:
-    SecretInteger: "65536"
+  my_input_0: 65536
 expected_outputs:
-  result_gelu:
-    SecretInteger: "-13"
-  result_cos:
-    SecretInteger: "-32566"
-  result_isqrt:
-    SecretInteger: "-2341"
-  result_gelu_motz:
-    SecretInteger: "0"
-  result_silu:
-    SecretInteger: "655340"
-  result_sin:
-    SecretInteger: "57328"
-  result_tanh_che:
-    SecretInteger: "19089"
-  result_tanh_motz:
-    SecretInteger: "24917"
-  result_silu_che:
-    SecretInteger: "0"
-  result_sig_motz:
-    SecretInteger: "65536"
-  result_tanh:
-    SecretInteger: "56624"
-  result_rec_log:
-    SecretInteger: "15552"
-  result_sig_che:
-    SecretInteger: "31130"
-  result_sig:
-    SecretInteger: "34401"
-  result_tan:
-    SecretInteger: "-922765"
-  result_sqrt:
-    SecretInteger: "262128"
-  result_log:
-    SecretInteger: "298843"
-  result_exp:
-    SecretInteger: "480249"
-  result_rec_NR:
-    SecretInteger: "32768"
+  result_gelu: -13
+  result_cos: -32566
+  result_isqrt: -2341
+  result_gelu_motz: 0
+  result_silu: 655340
+  result_sin: 57328
+  result_tanh_che: 19089
+  result_tanh_motz: 24917
+  result_silu_che: 0
+  result_sig_motz: 65536
+  result_tanh: 56624
+  result_rec_log: 15552
+  result_sig_che: 31130
+  result_sig: 34401
+  result_tan: -922765
+  result_sqrt: 262128
+  result_log: 298843
+  result_exp: 480249
+  result_rec_NR: 32768
+  result_silu_motz: 0

--- a/tests/nada-tests/tests/gauss_jordan.yaml
+++ b/tests/nada-tests/tests/gauss_jordan.yaml
@@ -1,41 +1,22 @@
 program: gauss_jordan
 inputs:
-  A_0_0:
-    SecretUnsignedInteger: '2'
-  A_0_1:
-    SecretUnsignedInteger: '4'
-  A_0_2:
-    SecretUnsignedInteger: '6'
-  A_1_0:
-    SecretUnsignedInteger: '1'
-  A_1_1:
-    SecretUnsignedInteger: '3'
-  A_1_2:
-    SecretUnsignedInteger: '5'
-  A_2_0:
-    SecretUnsignedInteger: '3'
-  A_2_1:
-    SecretUnsignedInteger: '1'
-  A_2_2:
-    SecretUnsignedInteger: '2'
-  B:
-    UnsignedInteger: '456'
+  A_0_0: 2
+  A_0_1: 4
+  A_0_2: 6
+  A_1_0: 1
+  A_1_1: 3
+  A_1_2: 5
+  A_2_0: 3
+  A_2_1: 1
+  A_2_2: 2
+  B: 456
 expected_outputs:
-  my_output_0_0:
-    UnsignedInteger: '1'
-  my_output_0_1:
-    UnsignedInteger: '0'
-  my_output_0_2:
-    UnsignedInteger: '0'
-  my_output_1_0:
-    UnsignedInteger: '0'
-  my_output_1_1:
-    UnsignedInteger: '1'
-  my_output_1_2:
-    UnsignedInteger: '0'
-  my_output_2_0:
-    UnsignedInteger: '0'
-  my_output_2_1:
-    UnsignedInteger: '0'
-  my_output_2_2:
-    UnsignedInteger: '1'
+  my_output_0_0: 1
+  my_output_0_1: 0
+  my_output_0_2: 0
+  my_output_1_0: 0
+  my_output_1_1: 1
+  my_output_1_2: 0
+  my_output_2_0: 0
+  my_output_2_1: 0
+  my_output_2_2: 1

--- a/tests/nada-tests/tests/generate_array.yaml
+++ b/tests/nada-tests/tests/generate_array.yaml
@@ -1,17 +1,10 @@
 program: generate_array
 inputs:
-  a:
-    SecretInteger: '3'
+  a: 3
 expected_outputs:
-  my_output_0_0:
-    SecretInteger: '8'
-  my_output_0_1:
-    SecretInteger: '8'
-  my_output_0_2:
-    SecretInteger: '8'
-  my_output_1_0:
-    SecretInteger: '8'
-  my_output_1_1:
-    SecretInteger: '8'
-  my_output_1_2:
-    SecretInteger: '8'
+  my_output_0_0: 8
+  my_output_0_1: 8
+  my_output_0_2: 8
+  my_output_1_0: 8
+  my_output_1_1: 8
+  my_output_1_2: 8

--- a/tests/nada-tests/tests/get_attr.yaml
+++ b/tests/nada-tests/tests/get_attr.yaml
@@ -1,11 +1,7 @@
 program: get_item
 inputs:
-  A_1:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
-  A_2:
-    SecretInteger: '3'
+  A_1: 3
+  A_0: 3
+  A_2: 3
 expected_outputs:
-  my_output:
-    SecretInteger: '9'
+  my_output: 9

--- a/tests/nada-tests/tests/get_item.yaml
+++ b/tests/nada-tests/tests/get_item.yaml
@@ -1,11 +1,7 @@
 program: get_item
 inputs:
-  A_1:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
-  A_2:
-    SecretInteger: '3'
+  A_1: 3
+  A_0: 3
+  A_2: 3
 expected_outputs:
-  my_output:
-    SecretInteger: '9'
+  my_output: 9

--- a/tests/nada-tests/tests/get_vec.yaml
+++ b/tests/nada-tests/tests/get_vec.yaml
@@ -1,27 +1,15 @@
 program: get_vec
 inputs:
-  A_2_1:
-    SecretInteger: '3'
-  A_0_0:
-    SecretInteger: '3'
-  A_1_1:
-    SecretInteger: '3'
-  A_1_2:
-    SecretInteger: '3'
-  A_0_1:
-    SecretInteger: '3'
-  A_0_2:
-    SecretInteger: '3'
-  A_1_0:
-    SecretInteger: '3'
-  A_2_2:
-    SecretInteger: '3'
-  A_2_0:
-    SecretInteger: '3'
+  A_2_1: 3
+  A_0_0: 3
+  A_1_1: 3
+  A_1_2: 3
+  A_0_1: 3
+  A_0_2: 3
+  A_1_0: 3
+  A_2_2: 3
+  A_2_0: 3
 expected_outputs:
-  my_output_0:
-    SecretInteger: '9'
-  my_output_1:
-    SecretInteger: '9'
-  my_output_2:
-    SecretInteger: '9'
+  my_output_0: 9
+  my_output_1: 9
+  my_output_2: 9

--- a/tests/nada-tests/tests/hstack.yaml
+++ b/tests/nada-tests/tests/hstack.yaml
@@ -1,27 +1,15 @@
 program: hstack
 inputs:
-  A_1:
-    SecretInteger: '3'
-  A_2:
-    SecretInteger: '3'
-  B_1:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
-  B_2:
-    SecretInteger: '3'
-  B_0:
-    SecretInteger: '3'
+  A_1: 3
+  A_2: 3
+  B_1: 3
+  A_0: 3
+  B_2: 3
+  B_0: 3
 expected_outputs:
-  my_output_4:
-    SecretInteger: '3'
-  my_output_3:
-    SecretInteger: '3'
-  my_output_5:
-    SecretInteger: '3'
-  my_output_1:
-    SecretInteger: '3'
-  my_output_0:
-    SecretInteger: '3'
-  my_output_2:
-    SecretInteger: '3'
+  my_output_4: 3
+  my_output_3: 3
+  my_output_5: 3
+  my_output_1: 3
+  my_output_0: 3
+  my_output_2: 3

--- a/tests/nada-tests/tests/logistic_regression.yaml
+++ b/tests/nada-tests/tests/logistic_regression.yaml
@@ -1,19 +1,11 @@
 program: logistic_regression
 inputs:
-  B_1:
-    SecretInteger: '65536'
-  A_1:
-    SecretInteger: '65536'
-  B_2:
-    SecretInteger: '65536'
-  bias:
-    SecretInteger: '65536'
-  A_0:
-    SecretInteger: '65536'
-  B_0:
-    SecretInteger: '65536'
-  A_2:
-    SecretInteger: '65536'
+  B_1: 65536
+  A_1: 65536
+  B_2: 65536
+  bias: 65536
+  A_0: 65536
+  B_0: 65536
+  A_2: 65536
 expected_outputs:
-  my_output:
-    SecretInteger: '12884967424'
+  my_output: 12884967424

--- a/tests/nada-tests/tests/logistic_regression_rational.yaml
+++ b/tests/nada-tests/tests/logistic_regression_rational.yaml
@@ -1,19 +1,11 @@
 program: logistic_regression_rational
 inputs:
-  B_1:
-    SecretInteger: '65536'
-  A_2:
-    SecretInteger: '65536'
-  B_2:
-    SecretInteger: '65536'
-  A_0:
-    SecretInteger: '65536'
-  B_0:
-    SecretInteger: '65536'
-  bias_0:
-    SecretInteger: '65536'
-  A_1:
-    SecretInteger: '65536'
+  B_1: 65536
+  A_2: 65536
+  B_2: 65536
+  A_0: 65536
+  B_0: 65536
+  bias_0: 65536
+  A_1: 65536
 expected_outputs:
-  my_output_0:
-    SecretInteger: '262144'
+  my_output_0: 262144

--- a/tests/nada-tests/tests/matrix_multiplication.yaml
+++ b/tests/nada-tests/tests/matrix_multiplication.yaml
@@ -1,57 +1,30 @@
 program: matrix_multiplication
 inputs:
-  A_0_0:
-    SecretInteger: '1'
-  A_0_1:
-    SecretInteger: '2'
-  A_0_2:
-    SecretInteger: '3'
-  A_1_0:
-    SecretInteger: '4'
-  A_1_1:
-    SecretInteger: '5'
-  A_1_2:
-    SecretInteger: '6'
-  A_2_0:
-    SecretInteger: '7'
-  A_2_1:
-    SecretInteger: '8'
-  A_2_2:
-    SecretInteger: '9'
-  B_0_0:
-    SecretInteger: '1'
-  B_0_1:
-    SecretInteger: '2'
-  B_0_2:
-    SecretInteger: '3'
-  B_1_0:
-    SecretInteger: '4'
-  B_1_1:
-    SecretInteger: '5'
-  B_1_2:
-    SecretInteger: '6'
-  B_2_0:
-    SecretInteger: '7'
-  B_2_1:
-    SecretInteger: '8'
-  B_2_2:
-    SecretInteger: '9'
+  A_0_0: 1
+  A_0_1: 2
+  A_0_2: 3
+  A_1_0: 4
+  A_1_1: 5
+  A_1_2: 6
+  A_2_0: 7
+  A_2_1: 8
+  A_2_2: 9
+  B_0_0: 1
+  B_0_1: 2
+  B_0_2: 3
+  B_1_0: 4
+  B_1_1: 5
+  B_1_2: 6
+  B_2_0: 7
+  B_2_1: 8
+  B_2_2: 9
 expected_outputs:
-  my_output_0_0:
-    SecretInteger: '30'
-  my_output_0_1:
-    SecretInteger: '36'
-  my_output_0_2:
-    SecretInteger: '42'
-  my_output_1_0:
-    SecretInteger: '66'
-  my_output_1_1:
-    SecretInteger: '81'
-  my_output_1_2:
-    SecretInteger: '96'
-  my_output_2_0:
-    SecretInteger: '102'
-  my_output_2_1:
-    SecretInteger: '126'
-  my_output_2_2:
-    SecretInteger: '150'
+  my_output_0_0: 30
+  my_output_0_1: 36
+  my_output_0_2: 42
+  my_output_1_0: 66
+  my_output_1_1: 81
+  my_output_1_2: 96
+  my_output_2_0: 102
+  my_output_2_1: 126
+  my_output_2_2: 150

--- a/tests/nada-tests/tests/matrix_multiplication_rational.yaml
+++ b/tests/nada-tests/tests/matrix_multiplication_rational.yaml
@@ -1,93 +1,54 @@
 program: matrix_multiplication_rational
 inputs:
-  A_0_0:
-    SecretInteger: '65536'
-  A_0_1:
-    SecretInteger: '131072'
-  A_0_2:
-    SecretInteger: '196608'
-  A_1_0:
-    SecretInteger: '262144'
-  A_1_1:
-    SecretInteger: '327680'
-  A_1_2:
-    SecretInteger: '393216'
-  A_2_0:
-    SecretInteger: '458752'
-  A_2_1:
-    SecretInteger: '524288'
-  A_2_2:
-    SecretInteger: '589824'
-  B_0_0:
-    SecretInteger: '65536'
-  B_0_1:
-    SecretInteger: '131072'
-  B_0_2:
-    SecretInteger: '196608'
-  B_1_0:
-    SecretInteger: '262144'
-  B_1_1:
-    SecretInteger: '327680'
-  B_1_2:
-    SecretInteger: '393216'
-  B_2_0:
-    SecretInteger: '458752'
-  B_2_1:
-    SecretInteger: '524288'
-  B_2_2:
-    SecretInteger: '589824'
-  C_0:
-    SecretInteger: '65536'
-  C_1:
-    SecretInteger: '0'
-  C_2:
-    SecretInteger: '0'
+  A_0_0: 65536
+  A_0_1: 131072
+  A_0_2: 196608
+  A_1_0: 262144
+  A_1_1: 327680
+  A_1_2: 393216
+  A_2_0: 458752
+  A_2_1: 524288
+  A_2_2: 589824
+  B_0_0: 65536
+  B_0_1: 131072
+  B_0_2: 196608
+  B_1_0: 262144
+  B_1_1: 327680
+  B_1_2: 393216
+  B_2_0: 458752
+  B_2_1: 524288
+  B_2_2: 589824
+  C_0: 65536
+  C_1: 0
+  C_2: 0
 expected_outputs:
-  my_output_0_0:
-    SecretInteger: '1966080'
-  my_output_0_1:
-    SecretInteger: '2359296'
-  my_output_0_2:
-    SecretInteger: '2752512'
-  my_output_1_0:
-    SecretInteger: '4325376'
-  my_output_1_1:
-    SecretInteger: '5308416'
-  my_output_1_2:
-    SecretInteger: '6291456'
-  my_output_2_0:
-    SecretInteger: '6684672'
-  my_output_2_1:
-    SecretInteger: '8257536'
-  my_output_2_2:
-    SecretInteger: '9830400'
-  my_output_b_0:
-    SecretInteger: '65536'
-  my_output_b_1:
-    SecretInteger: '262144'
-  my_output_b_2:
-    SecretInteger: '458752'
-  my_output_c_0_0:
-    SecretInteger: '393216'
-  my_output_c_0_1:
-    SecretInteger: '393216'
-  my_output_c_0_2:
-    SecretInteger: '393216'
-  my_output_c_1_0:
-    SecretInteger: '983040'
-  my_output_c_1_1:
-    SecretInteger: '983040'
-  my_output_c_1_2:
-    SecretInteger: '983040'
-  my_output_c_2_0:
-    SecretInteger: '1572864'
-  my_output_c_2_1:
-    SecretInteger: '1572864'
-  my_output_c_2_2:
-    SecretInteger: '1572864'
-  my_output_d_0_0:
-    SecretInteger: '786432'
-  my_output_d_1_0:
-    SecretInteger: '786432'
-  my_output_d_2_0:
-    SecretInteger: '786432'
+  my_output_0_0: 1966080
+  my_output_0_1: 2359296
+  my_output_0_2: 2752512
+  my_output_1_0: 4325376
+  my_output_1_1: 5308416
+  my_output_1_2: 6291456
+  my_output_2_0: 6684672
+  my_output_2_1: 8257536
+  my_output_2_2: 9830400
+  my_output_b_0: 65536
+  my_output_b_1: 262144
+  my_output_b_2: 458752
+  my_output_c_0_0: 393216
+  my_output_c_0_1: 393216
+  my_output_c_0_2: 393216
+  my_output_c_1_0: 983040
+  my_output_c_1_1: 983040
+  my_output_c_1_2: 983040
+  my_output_c_2_0: 1572864
+  my_output_c_2_1: 1572864
+  my_output_c_2_2: 1572864
+  my_output_d_0_0: 786432
+  my_output_d_0_1: 983040
+  my_output_d_0_2: 1179648
+  my_output_d_1_0: 786432
+  my_output_d_1_1: 983040
+  my_output_d_1_2: 1179648
+  my_output_d_2_0: 786432
+  my_output_d_2_1: 983040
+  my_output_d_2_2: 1179648

--- a/tests/nada-tests/tests/matrix_multiplication_rational_multidim.yaml
+++ b/tests/nada-tests/tests/matrix_multiplication_rational_multidim.yaml
@@ -1,167 +1,96 @@
 program: matrix_multiplication_rational_multidim
 inputs:
-  A_0_0_0_0_0_0:
-    SecretInteger: '65536'
-  A_0_0_0_0_0_1:
-    SecretInteger: '131072'
-  A_0_0_0_0_1_0:
-    SecretInteger: '196608'
-  A_0_0_0_0_1_1:
-    SecretInteger: '262144'
-  A_0_0_0_1_0_0:
-    SecretInteger: '65536'
-  A_0_0_0_1_0_1:
-    SecretInteger: '131072'
-  A_0_0_0_1_1_0:
-    SecretInteger: '196608'
-  A_0_0_0_1_1_1:
-    SecretInteger: '262144'
-  A_1_0_0_0_0_0:
-    SecretInteger: '65536'
-  A_1_0_0_0_0_1:
-    SecretInteger: '131072'
-  A_1_0_0_0_1_0:
-    SecretInteger: '196608'
-  A_1_0_0_0_1_1:
-    SecretInteger: '262144'
-  A_1_0_0_1_0_0:
-    SecretInteger: '65536'
-  A_1_0_0_1_0_1:
-    SecretInteger: '131072'
-  A_1_0_0_1_1_0:
-    SecretInteger: '196608'
-  A_1_0_0_1_1_1:
-    SecretInteger: '262144'
-  B_0_0_0_0_0_0:
-    SecretInteger: '65536'
-  B_0_0_0_0_0_1:
-    SecretInteger: '131072'
-  B_0_0_0_0_1_0:
-    SecretInteger: '196608'
-  B_0_0_0_0_1_1:
-    SecretInteger: '262144'
-  B_0_0_0_1_0_0:
-    SecretInteger: '65536'
-  B_0_0_0_1_0_1:
-    SecretInteger: '131072'
-  B_0_0_0_1_1_0:
-    SecretInteger: '196608'
-  B_0_0_0_1_1_1:
-    SecretInteger: '262144'
-  B_1_0_0_0_0_0:
-    SecretInteger: '65536'
-  B_1_0_0_0_0_1:
-    SecretInteger: '131072'
-  B_1_0_0_0_1_0:
-    SecretInteger: '196608'
-  B_1_0_0_0_1_1:
-    SecretInteger: '262144'
-  B_1_0_0_1_0_0:
-    SecretInteger: '65536'
-  B_1_0_0_1_0_1:
-    SecretInteger: '131072'
-  B_1_0_0_1_1_0:
-    SecretInteger: '196608'
-  B_1_0_0_1_1_1:
-    SecretInteger: '262144'
-  C_0:
-    SecretInteger: '65536'
-  C_1:
-    SecretInteger: '0'
+  A_0_0_0_0_0_0: 65536
+  A_0_0_0_0_0_1: 131072
+  A_0_0_0_0_1_0: 196608
+  A_0_0_0_0_1_1: 262144
+  A_0_0_0_1_0_0: 65536
+  A_0_0_0_1_0_1: 131072
+  A_0_0_0_1_1_0: 196608
+  A_0_0_0_1_1_1: 262144
+  A_1_0_0_0_0_0: 65536
+  A_1_0_0_0_0_1: 131072
+  A_1_0_0_0_1_0: 196608
+  A_1_0_0_0_1_1: 262144
+  A_1_0_0_1_0_0: 65536
+  A_1_0_0_1_0_1: 131072
+  A_1_0_0_1_1_0: 196608
+  A_1_0_0_1_1_1: 262144
+  B_0_0_0_0_0_0: 65536
+  B_0_0_0_0_0_1: 131072
+  B_0_0_0_0_1_0: 196608
+  B_0_0_0_0_1_1: 262144
+  B_0_0_0_1_0_0: 65536
+  B_0_0_0_1_0_1: 131072
+  B_0_0_0_1_1_0: 196608
+  B_0_0_0_1_1_1: 262144
+  B_1_0_0_0_0_0: 65536
+  B_1_0_0_0_0_1: 131072
+  B_1_0_0_0_1_0: 196608
+  B_1_0_0_0_1_1: 262144
+  B_1_0_0_1_0_0: 65536
+  B_1_0_0_1_0_1: 131072
+  B_1_0_0_1_1_0: 196608
+  B_1_0_0_1_1_1: 262144
+  C_0: 65536
+  C_1: 0
 expected_outputs:
-  my_output_0_0_0_0_0_0:
-    SecretInteger: '458752'
-  my_output_0_0_0_0_0_1:
-    SecretInteger: '655360'
-  my_output_0_0_0_0_1_0:
-    SecretInteger: '983040'
-  my_output_0_0_0_0_1_1:
-    SecretInteger: '1441792'
-  my_output_0_0_0_1_0_0:
-    SecretInteger: '458752'
-  my_output_0_0_0_1_0_1:
-    SecretInteger: '655360'
-  my_output_0_0_0_1_1_0:
-    SecretInteger: '983040'
-  my_output_0_0_0_1_1_1:
-    SecretInteger: '1441792'
-  my_output_1_0_0_0_0_0:
-    SecretInteger: '458752'
-  my_output_1_0_0_0_0_1:
-    SecretInteger: '655360'
-  my_output_1_0_0_0_1_0:
-    SecretInteger: '983040'
-  my_output_1_0_0_0_1_1:
-    SecretInteger: '1441792'
-  my_output_1_0_0_1_0_0:
-    SecretInteger: '458752'
-  my_output_1_0_0_1_0_1:
-    SecretInteger: '655360'
-  my_output_1_0_0_1_1_0:
-    SecretInteger: '983040'
-  my_output_1_0_0_1_1_1:
-    SecretInteger: '1441792'
-  my_output_b_0_0_0_0_0:
-    SecretInteger: '65536'
-  my_output_b_0_0_0_0_1:
-    SecretInteger: '196608'
-  my_output_b_0_0_0_1_0:
-    SecretInteger: '65536'
-  my_output_b_0_0_0_1_1:
-    SecretInteger: '196608'
-  my_output_b_1_0_0_0_0:
-    SecretInteger: '65536'
-  my_output_b_1_0_0_0_1:
-    SecretInteger: '196608'
-  my_output_b_1_0_0_1_0:
-    SecretInteger: '65536'
-  my_output_b_1_0_0_1_1:
-    SecretInteger: '196608'
-  my_output_c_0_0_0_0_0_0:
-    SecretInteger: '196608'
-  my_output_c_0_0_0_0_0_1:
-    SecretInteger: '196608'
-  my_output_c_0_0_0_0_1_0:
-    SecretInteger: '458752'
-  my_output_c_0_0_0_0_1_1:
-    SecretInteger: '458752'
-  my_output_c_0_0_0_1_0_0:
-    SecretInteger: '196608'
-  my_output_c_0_0_0_1_0_1:
-    SecretInteger: '196608'
-  my_output_c_0_0_0_1_1_0:
-    SecretInteger: '458752'
-  my_output_c_0_0_0_1_1_1:
-    SecretInteger: '458752'
-  my_output_c_1_0_0_0_0_0:
-    SecretInteger: '196608'
-  my_output_c_1_0_0_0_0_1:
-    SecretInteger: '196608'
-  my_output_c_1_0_0_0_1_0:
-    SecretInteger: '458752'
-  my_output_c_1_0_0_0_1_1:
-    SecretInteger: '458752'
-  my_output_c_1_0_0_1_0_0:
-    SecretInteger: '196608'
-  my_output_c_1_0_0_1_0_1:
-    SecretInteger: '196608'
-  my_output_c_1_0_0_1_1_0:
-    SecretInteger: '458752'
-  my_output_c_1_0_0_1_1_1:
-    SecretInteger: '458752'
-  my_output_d_0_0_0_1_0_0:
-    SecretInteger: '262144'
-  my_output_d_0_0_0_1_0_1:
-    SecretInteger: '393216'
-  my_output_d_0_0_0_1_1_0:
-    SecretInteger: '262144'
-  my_output_d_0_0_0_1_1_1:
-    SecretInteger: '393216'
-  my_output_d_1_0_0_1_0_0:
-    SecretInteger: '262144'
-  my_output_d_1_0_0_1_0_1:
-    SecretInteger: '393216'
-  my_output_d_1_0_0_1_1_0:
-    SecretInteger: '262144'
-  my_output_d_1_0_0_1_1_1:
-    SecretInteger: '393216'
+  my_output_0_0_0_0_0_0: 458752
+  my_output_0_0_0_0_0_1: 655360
+  my_output_0_0_0_0_1_0: 983040
+  my_output_0_0_0_0_1_1: 1441792
+  my_output_0_0_0_1_0_0: 458752
+  my_output_0_0_0_1_0_1: 655360
+  my_output_0_0_0_1_1_0: 983040
+  my_output_0_0_0_1_1_1: 1441792
+  my_output_1_0_0_0_0_0: 458752
+  my_output_1_0_0_0_0_1: 655360
+  my_output_1_0_0_0_1_0: 983040
+  my_output_1_0_0_0_1_1: 1441792
+  my_output_1_0_0_1_0_0: 458752
+  my_output_1_0_0_1_0_1: 655360
+  my_output_1_0_0_1_1_0: 983040
+  my_output_1_0_0_1_1_1: 1441792
+  my_output_b_0_0_0_0_0: 65536
+  my_output_b_0_0_0_0_1: 196608
+  my_output_b_0_0_0_1_0: 65536
+  my_output_b_0_0_0_1_1: 196608
+  my_output_b_1_0_0_0_0: 65536
+  my_output_b_1_0_0_0_1: 196608
+  my_output_b_1_0_0_1_0: 65536
+  my_output_b_1_0_0_1_1: 196608
+  my_output_c_0_0_0_0_0_0: 196608
+  my_output_c_0_0_0_0_0_1: 196608
+  my_output_c_0_0_0_0_1_0: 458752
+  my_output_c_0_0_0_0_1_1: 458752
+  my_output_c_0_0_0_1_0_0: 196608
+  my_output_c_0_0_0_1_0_1: 196608
+  my_output_c_0_0_0_1_1_0: 458752
+  my_output_c_0_0_0_1_1_1: 458752
+  my_output_c_1_0_0_0_0_0: 196608
+  my_output_c_1_0_0_0_0_1: 196608
+  my_output_c_1_0_0_0_1_0: 458752
+  my_output_c_1_0_0_0_1_1: 458752
+  my_output_c_1_0_0_1_0_0: 196608
+  my_output_c_1_0_0_1_0_1: 196608
+  my_output_c_1_0_0_1_1_0: 458752
+  my_output_c_1_0_0_1_1_1: 458752
+  my_output_d_0_0_0_0_0_0: 262144
+  my_output_d_0_0_0_0_0_1: 393216
+  my_output_d_0_0_0_0_1_0: 262144
+  my_output_d_0_0_0_0_1_1: 393216
+  my_output_d_0_0_0_1_0_0: 262144
+  my_output_d_0_0_0_1_0_1: 393216
+  my_output_d_0_0_0_1_1_0: 262144
+  my_output_d_0_0_0_1_1_1: 393216
+  my_output_d_1_0_0_0_0_0: 262144
+  my_output_d_1_0_0_0_0_1: 393216
+  my_output_d_1_0_0_0_1_0: 262144
+  my_output_d_1_0_0_0_1_1: 393216
+  my_output_d_1_0_0_1_0_0: 262144
+  my_output_d_1_0_0_1_0_1: 393216
+  my_output_d_1_0_0_1_1_0: 262144
+  my_output_d_1_0_0_1_1_1: 393216
+
+
+

--- a/tests/nada-tests/tests/private_inverse.yaml
+++ b/tests/nada-tests/tests/private_inverse.yaml
@@ -1,7 +1,5 @@
 program: private_inverse
 inputs:
-  A_0:
-    SecretUnsignedInteger: '3'
+  A_0: 3
 expected_outputs:
-  my_output:
-    SecretUnsignedInteger: '1'
+  my_output: 1

--- a/tests/nada-tests/tests/random_array.yaml
+++ b/tests/nada-tests/tests/random_array.yaml
@@ -1,15 +1,9 @@
 program: random_array
 inputs:
-  A_1:
-    SecretInteger: '3'
-  A_2:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
+  A_1: 3
+  A_2: 3
+  A_0: 3
 expected_outputs:
-  my_output_0:
-    SecretInteger: '3'
-  my_output_1:
-    SecretInteger: '3'
-  my_output_2:
-    SecretInteger: '3'
+  my_output_0: 3
+  my_output_1: 3
+  my_output_2: 3

--- a/tests/nada-tests/tests/rational_advanced.yaml
+++ b/tests/nada-tests/tests/rational_advanced.yaml
@@ -1,31 +1,17 @@
 program: rational_advanced
 inputs:
-  my_input_0:
-    SecretInteger: '209715'
-  my_input_1:
-    Integer: '1229'
+  my_input_0: 209715
+  my_input_1: 1229
 expected_outputs:
-  out_3:
-    SecretInteger: '16495343040'
-  out_5:
-    SecretInteger: '11182979'
-  out_8:
-    Integer: '1475'
-  out_0:
-    SecretInteger: '174734'
-  out_7:
-    SecretInteger: '170'
-  out_9:
-    Integer: '4194304'
-  out_10:
-    Integer: '96668224'
-  out_2:
-    SecretInteger: '24580'
-  out_1:
-    SecretInteger: '16495343040'
-  out_4:
-    SecretInteger: '3932'
-  out_6:
-    SecretInteger: '257739735'
-  out_11:
-    Integer: '64'
+  out_3: 16495343040
+  out_5: 11182979
+  out_8: 1475
+  out_0: 174734
+  out_7: 170
+  out_9: 4194304
+  out_10: 96668224
+  out_2: 24580
+  out_1: 16495343040
+  out_4: 3932
+  out_6: 257739735
+  out_11: 64

--- a/tests/nada-tests/tests/rational_arithmetic.yaml
+++ b/tests/nada-tests/tests/rational_arithmetic.yaml
@@ -1,29 +1,16 @@
 program: rational_arithmetic
 inputs:
-  my_input_1:
-    SecretInteger: '78643'
-  my_input_0:
-    Integer: '294912'
+  my_input_1: 78643
+  my_input_0: 294912
 expected_outputs:
-  my_output_0:
-    Integer: '504627'
-  my_output_1:
-    Integer: '-85197'
-  my_output_2:
-    Integer: '943717'
-  my_output_3:
-    Integer: '46603'
-  my_output_4:
-    SecretInteger: '288358'
-  my_output_5:
-    SecretInteger: '131072'
-  my_output_6:
-    SecretInteger: '251657'
-  my_output_7:
-    SecretInteger: '174762'
-  my_output_8:
-    Integer: '720568878'
-  my_output_9:
-    Integer: '65536'
-  my_output_10:
-    Integer: '2000'
+  my_output_0: 504627
+  my_output_1: -85197
+  my_output_2: 943717
+  my_output_3: 46603
+  my_output_4: 288358
+  my_output_5: 131072
+  my_output_6: 251657
+  my_output_7: 174762
+  my_output_8: 720568878
+  my_output_9: 65536
+  my_output_10: 2000

--- a/tests/nada-tests/tests/rational_array.yaml
+++ b/tests/nada-tests/tests/rational_array.yaml
@@ -1,69 +1,36 @@
 program: rational_array
 inputs:
-  A_0:
-    SecretInteger: '0'
-  A_1:
-    SecretInteger: '65536'
-  A_2:
-    SecretInteger: '131072'
-  B_0:
-    SecretInteger: '65536'
-  B_1:
-    SecretInteger: '131072'
-  B_2:
-    SecretInteger: '196608'
+  A_0: 0
+  A_1: 65536
+  A_2: 131072
+  B_0: 65536
+  B_1: 131072
+  B_2: 196608
 expected_outputs:
-  out_0_0:
-    SecretInteger: '65536'
-  out_0_1:
-    SecretInteger: '196608'
-  out_0_2:
-    SecretInteger: '327680'
-  out_1_0:
-    SecretInteger: '-65536'
-  out_1_1:
-    SecretInteger: '-65536'
-  out_1_2:
-    SecretInteger: '-65536'
-  out_2_0:
-    SecretInteger: '0'
-  out_2_1:
-    SecretInteger: '131072'
-  out_2_2:
-    SecretInteger: '393216'
-  out_3_0:
-    SecretInteger: '0'
-  out_3_1:
-    SecretInteger: '32768'
-  out_3_2:
-    SecretInteger: '43690'
-  out_4_0:
-    SecretInteger: '65536'
-  out_4_1:
-    SecretInteger: '131072'
-  out_4_2:
-    SecretInteger: '196608'
-  out_5_0:
-    SecretInteger: '-65536'
-  out_5_1:
-    SecretInteger: '0'
-  out_5_2:
-    SecretInteger: '65536'
-  out_6_0:
-    SecretInteger: '0'
-  out_6_1:
-    SecretInteger: '65536'
-  out_6_2:
-    SecretInteger: '131072'
-  out_7_0:
-    SecretInteger: '0'
-  out_7_1:
-    SecretInteger: '65536'
-  out_7_2:
-    SecretInteger: '131072'
-  out_8_0:
-    SecretInteger: '0'
-  out_8_1:
-    SecretInteger: '-65536'
-  out_8_2:
-    SecretInteger: '-131072'
+  out_0_0: 65536
+  out_0_1: 196608
+  out_0_2: 327680
+  out_1_0: -65536
+  out_1_1: -65536
+  out_1_2: -65536
+  out_2_0: 0
+  out_2_1: 131072
+  out_2_2: 393216
+  out_3_0: 0
+  out_3_1: 32768
+  out_3_2: 43690
+  out_4_0: 65536
+  out_4_1: 131072
+  out_4_2: 196608
+  out_5_0: -65536
+  out_5_1: 0
+  out_5_2: 65536
+  out_6_0: 0
+  out_6_1: 65536
+  out_6_2: 131072
+  out_7_0: 0
+  out_7_1: 65536
+  out_7_2: 131072
+  out_8_0: 0
+  out_8_1: -65536
+  out_8_2: -131072

--- a/tests/nada-tests/tests/rational_comparison.yaml
+++ b/tests/nada-tests/tests/rational_comparison.yaml
@@ -1,37 +1,20 @@
 program: rational_comparison
 inputs:
-  my_input_0:
-    SecretInteger: '78643'
-  my_input_1:
-    Integer: '209715'
+  my_input_0: 78643
+  my_input_1: 209715
 expected_outputs:
-  my_output_0:
-    Boolean: true
-  my_output_1:
-    Boolean: true
-  my_output_2:
-    Boolean: false
-  my_output_3:
-    Boolean: false
-  my_output_4:
-    Boolean: false
-  my_output_5:
-    SecretBoolean: false
-  my_output_6:
-    SecretBoolean: false
-  my_output_7:
-    SecretBoolean: true
-  my_output_8:
-    SecretBoolean: true
-  my_output_9:
-    SecretBoolean: false
-  my_output_10:
-    Boolean: true
-  my_output_12:
-    Boolean: true
-  my_output_13:
-    Boolean: true
-  my_output_14:
-    Boolean: false
-  my_output_15:
-    Boolean: false
+  my_output_0: true
+  my_output_1: true
+  my_output_2: false
+  my_output_3: false
+  my_output_4: false
+  my_output_5: false
+  my_output_6: false
+  my_output_7: true
+  my_output_8: true
+  my_output_9: false
+  my_output_10: true
+  my_output_12: true
+  my_output_13: true
+  my_output_14: false
+  my_output_15: false

--- a/tests/nada-tests/tests/rational_if_else.yaml
+++ b/tests/nada-tests/tests/rational_if_else.yaml
@@ -1,39 +1,23 @@
 program: rational_if_else
 inputs:
-  A:
-    SecretInteger: '78643'
-  B:
-    SecretInteger: '294912'
-  C:
-    SecretInteger: '65536'
-  D:
-    SecretInteger: '1'
-  E:
-    SecretUnsignedInteger: '1'
+  A: 78643
+  B: 294912
+  C: 65536
+  D: 1
+  E: 1
 expected_outputs:
-  out_0:
-    SecretInteger: '294912'
-  out_1:
-    SecretInteger: '294912'
-  out_2:
-    SecretInteger: '78643'
-  out_3:
-    SecretInteger: '78643'
-  out_4:
-    SecretInteger: '1'
-  out_5:
-    SecretInteger: '1'
-  out_6:
-    SecretInteger: '1'
-  out_7:
-    SecretInteger: '1'
-  out_8:
-    Integer: '131072'
-  out_9:
-    Integer: '65536'
-  out_10:
-    Integer: '1'
-  out_11:
-    SecretInteger: '1'
-  out_12:
-    SecretUnsignedInteger: '1'
+  out_0: 294912
+  out_1: 294912
+  out_2: 78643
+  out_3: 78643
+  out_4: 1
+  out_5: 1
+  out_6: 1
+  out_7: 1
+  out_8: 131072
+  out_9: 65536
+  out_10: 1
+  out_11: 1
+  out_12: 1
+
+  out_13: 1

--- a/tests/nada-tests/tests/rational_operability.yaml
+++ b/tests/nada-tests/tests/rational_operability.yaml
@@ -1,21 +1,12 @@
 program: rational_operability
 inputs:
-  A_1:
-    SecretInteger: '196608'
-  A_2:
-    SecretInteger: '196608'
-  A_0:
-    SecretInteger: '196608'
-  B_1:
-    Integer: '131072'
-  B_2:
-    Integer: '131072'
-  B_0:
-    Integer: '131072'
+  A_1: 196608
+  A_2: 196608
+  A_0: 196608
+  B_1: 131072
+  B_2: 131072
+  B_0: 131072
 expected_outputs:
-  my_output_0:
-    SecretInteger: '327680'
-  my_output_1:
-    SecretInteger: '327680'
-  my_output_2:
-    SecretInteger: '327680'
+  my_output_0: 327680
+  my_output_1: 327680
+  my_output_2: 327680

--- a/tests/nada-tests/tests/rational_scaling.yaml
+++ b/tests/nada-tests/tests/rational_scaling.yaml
@@ -1,15 +1,9 @@
 program: rational_scaling
 inputs:
-  A_1:
-    SecretInteger: '12884901888'
-  A_2:
-    SecretInteger: '12884901888'
-  A_0:
-    SecretInteger: '12884901888'
+  A_1: 12884901888
+  A_2: 12884901888
+  A_0: 12884901888
 expected_outputs:
-  my_output_0:
-    SecretInteger: '21474836480'
-  my_output_1:
-    SecretInteger: '21474836480'
-  my_output_2:
-    SecretInteger: '21474836480'
+  my_output_0: 21474836480
+  my_output_1: 21474836480
+  my_output_2: 21474836480

--- a/tests/nada-tests/tests/reveal.yaml
+++ b/tests/nada-tests/tests/reveal.yaml
@@ -1,75 +1,39 @@
 program: reveal
 inputs:
-  A_0_0:
-    SecretInteger: '3'
-  A_0_2:
-    SecretInteger: '3'
-  A_1_2:
-    SecretInteger: '3'
-  B_1_2:
-    SecretInteger: '3'
-  A_1_0:
-    SecretInteger: '3'
-  B_2_2:
-    SecretInteger: '3'
-  B_2_1:
-    SecretInteger: '3'
-  B_0_1:
-    SecretInteger: '3'
-  A_2_1:
-    SecretInteger: '3'
-  A_1_1:
-    SecretInteger: '3'
-  A_0_1:
-    SecretInteger: '3'
-  B_1_1:
-    SecretInteger: '3'
-  A_2_2:
-    SecretInteger: '3'
-  B_0_0:
-    SecretInteger: '3'
-  A_2_0:
-    SecretInteger: '3'
-  B_1_0:
-    SecretInteger: '3'
-  B_2_0:
-    SecretInteger: '3'
-  B_0_2:
-    SecretInteger: '3'
+  A_0_0: 3
+  A_0_2: 3
+  A_1_2: 3
+  B_1_2: 3
+  A_1_0: 3
+  B_2_2: 3
+  B_2_1: 3
+  B_0_1: 3
+  A_2_1: 3
+  A_1_1: 3
+  A_0_1: 3
+  B_1_1: 3
+  A_2_2: 3
+  B_0_0: 3
+  A_2_0: 3
+  B_1_0: 3
+  B_2_0: 3
+  B_0_2: 3
 expected_outputs:
-  my_output_B_0_1:
-    Integer: '3'
-  my_output_A_0_1:
-    Integer: '3'
-  my_output_A_0_2:
-    Integer: '3'
-  my_output_B_0_2:
-    Integer: '3'
-  my_output_A_1_1:
-    Integer: '3'
-  my_output_B_1_1:
-    Integer: '3'
-  my_output_A_2_2:
-    Integer: '3'
-  my_output_A_2_1:
-    Integer: '3'
-  my_output_A_2_0:
-    Integer: '3'
-  my_output_B_2_1:
-    Integer: '3'
-  my_output_A_1_2:
-    Integer: '3'
-  my_output_B_1_0:
-    Integer: '3'
-  my_output_B_2_2:
-    Integer: '3'
-  my_output_A_1_0:
-    Integer: '3'
-  my_output_B_2_0:
-    Integer: '3'
-  my_output_B_1_2:
-    Integer: '3'
-  my_output_A_0_0:
-    Integer: '3'
-  my_output_B_0_0:
-    Integer: '3'
+  my_output_B_0_1: 3
+  my_output_A_0_1: 3
+  my_output_A_0_2: 3
+  my_output_B_0_2: 3
+  my_output_A_1_1: 3
+  my_output_B_1_1: 3
+  my_output_A_2_2: 3
+  my_output_A_2_1: 3
+  my_output_A_2_0: 3
+  my_output_B_2_1: 3
+  my_output_A_1_2: 3
+  my_output_B_1_0: 3
+  my_output_B_2_2: 3
+  my_output_A_1_0: 3
+  my_output_B_2_0: 3
+  my_output_B_1_2: 3
+  my_output_A_0_0: 3
+  my_output_B_0_0: 3

--- a/tests/nada-tests/tests/secret_rational_arithmetic.yaml
+++ b/tests/nada-tests/tests/secret_rational_arithmetic.yaml
@@ -1,29 +1,16 @@
 program: secret_rational_arithmetic
 inputs:
-  my_input_0:
-    SecretInteger: '209715'
-  my_input_1:
-    SecretInteger: '294912'
+  my_input_0: 209715
+  my_input_1: 294912
 expected_outputs:
-  my_output_0:
-    SecretInteger: '504627'
-  my_output_1:
-    SecretInteger: '-85197'
-  my_output_2:
-    SecretInteger: '943717'
-  my_output_3:
-    SecretInteger: '46603'
-  my_output_4:
-    SecretInteger: '288358'
-  my_output_5:
-    SecretInteger: '131072'
-  my_output_6:
-    SecretInteger: '251657'
-  my_output_7:
-    SecretInteger: '174762'
-  my_output_8:
-    SecretInteger: '720568878'
-  my_output_9:
-    SecretInteger: '-209715'
-  my_output_12:
-    Integer: '209715'
+  my_output_0: 504627
+  my_output_1: -85197
+  my_output_2: 943717
+  my_output_3: 46603
+  my_output_4: 288358
+  my_output_5: 131072
+  my_output_6: 251657
+  my_output_7: 174762
+  my_output_8: 720568878
+  my_output_9: -209715
+  my_output_12: 209715

--- a/tests/nada-tests/tests/secret_rational_comparison.yaml
+++ b/tests/nada-tests/tests/secret_rational_comparison.yaml
@@ -1,39 +1,21 @@
 program: secret_rational_comparison
 inputs:
-  my_input_0:
-    SecretInteger: '209715'
-  my_input_1:
-    SecretInteger: '294912'
-  my_input_2:
-    SecretInteger: '209715'
+  my_input_0: 209715
+  my_input_1: 294912
+  my_input_2: 209715
 expected_outputs:
-  my_output_0:
-    SecretBoolean: true
-  my_output_1:
-    SecretBoolean: true
-  my_output_2:
-    SecretBoolean: false
-  my_output_3:
-    SecretBoolean: false
-  my_output_4:
-    SecretBoolean: false
-  my_output_5:
-    SecretBoolean: false
-  my_output_6:
-    SecretBoolean: false
-  my_output_7:
-    SecretBoolean: true
-  my_output_8:
-    SecretBoolean: true
-  my_output_9:
-    SecretBoolean: false
-  my_output_10:
-    SecretBoolean: true
-  my_output_12:
-    SecretBoolean: true
-  my_output_13:
-    SecretBoolean: true
-  my_output_14:
-    SecretBoolean: false
-  my_output_15:
-    SecretBoolean: false
+  my_output_0: true
+  my_output_1: true
+  my_output_2: false
+  my_output_3: false
+  my_output_4: false
+  my_output_5: false
+  my_output_6: false
+  my_output_7: true
+  my_output_8: true
+  my_output_9: false
+  my_output_10: true
+  my_output_12: true
+  my_output_13: true
+  my_output_14: false
+  my_output_15: false

--- a/tests/nada-tests/tests/set_item.yaml
+++ b/tests/nada-tests/tests/set_item.yaml
@@ -1,27 +1,15 @@
 program: set_item
 inputs:
-  A_2_1:
-    SecretInteger: '3'
-  A_1_1:
-    SecretInteger: '3'
-  A_2_2:
-    SecretInteger: '3'
-  A_0_0:
-    SecretInteger: '3'
-  A_1_0:
-    SecretInteger: '3'
-  A_1_2:
-    SecretInteger: '3'
-  A_2_0:
-    SecretInteger: '3'
-  A_0_2:
-    SecretInteger: '3'
-  A_0_1:
-    SecretInteger: '3'
+  A_2_1: 3
+  A_1_1: 3
+  A_2_2: 3
+  A_0_0: 3
+  A_1_0: 3
+  A_1_2: 3
+  A_2_0: 3
+  A_0_2: 3
+  A_0_1: 3
 expected_outputs:
-  my_output_1:
-    SecretInteger: '11'
-  my_output_2:
-    SecretInteger: '12'
-  my_output_0:
-    SecretInteger: '10'
+  my_output_1: 11
+  my_output_2: 12
+  my_output_0: 10

--- a/tests/nada-tests/tests/shape.yaml
+++ b/tests/nada-tests/tests/shape.yaml
@@ -1,27 +1,15 @@
 program: shape
 inputs:
-  A_2_1:
-    SecretInteger: '3'
-  A_0_0:
-    SecretInteger: '3'
-  A_1_1:
-    SecretInteger: '3'
-  A_1_2:
-    SecretInteger: '3'
-  A_0_1:
-    SecretInteger: '3'
-  A_0_2:
-    SecretInteger: '3'
-  A_1_0:
-    SecretInteger: '3'
-  A_2_2:
-    SecretInteger: '3'
-  A_2_0:
-    SecretInteger: '3'
+  A_2_1: 3
+  A_0_0: 3
+  A_1_1: 3
+  A_1_2: 3
+  A_0_1: 3
+  A_0_2: 3
+  A_1_0: 3
+  A_2_2: 3
+  A_2_0: 3
 expected_outputs:
-  my_output_0:
-    SecretInteger: '9'
-  my_output_1:
-    SecretInteger: '9'
-  my_output_2:
-    SecretInteger: '9'
+  my_output_0: 9
+  my_output_1: 9
+  my_output_2: 9

--- a/tests/nada-tests/tests/sum.yaml
+++ b/tests/nada-tests/tests/sum.yaml
@@ -1,11 +1,7 @@
 program: sum
 inputs:
-  A_1:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
-  A_2:
-    SecretInteger: '3'
+  A_1: 3
+  A_0: 3
+  A_2: 3
 expected_outputs:
-  my_output:
-    SecretInteger: '9'
+  my_output: 9

--- a/tests/nada-tests/tests/supported_operations.yaml
+++ b/tests/nada-tests/tests/supported_operations.yaml
@@ -1,91 +1,47 @@
 program: supported_operations
 inputs:
-  A_0_0:
-    SecretInteger: '1'
-  A_0_1:
-    SecretInteger: '2'
-  A_0_2:
-    SecretInteger: '3'
-  A_1_0:
-    SecretInteger: '4'
-  A_1_1:
-    SecretInteger: '5'
-  A_1_2:
-    SecretInteger: '6'
-  A_2_0:
-    SecretInteger: '7'
-  A_2_1:
-    SecretInteger: '8'
-  A_2_2:
-    SecretInteger: '9'
-  B_0_0:
-    SecretInteger: '1'
-  B_0_1:
-    SecretInteger: '2'
-  B_0_2:
-    SecretInteger: '3'
-  B_1_0:
-    SecretInteger: '4'
-  B_1_1:
-    SecretInteger: '5'
-  B_1_2:
-    SecretInteger: '6'
-  B_2_0:
-    SecretInteger: '7'
-  B_2_1:
-    SecretInteger: '8'
-  B_2_2:
-    SecretInteger: '9'
-  C_0_0:
-    SecretInteger: '1'
-  C_0_1:
-    SecretInteger: '2'
-  C_0_2:
-    SecretInteger: '3'
-  C_1_0:
-    SecretInteger: '4'
-  C_1_1:
-    SecretInteger: '5'
-  C_1_2:
-    SecretInteger: '6'
-  C_2_0:
-    SecretInteger: '7'
-  C_2_1:
-    SecretInteger: '8'
-  C_2_2:
-    SecretInteger: '9'
-  D_0:
-    SecretInteger: '1'
-  E_0_0:
-    SecretInteger: '1'
-  E_0_1:
-    SecretInteger: '2'
-  E_0_2:
-    SecretInteger: '3'
-  E_1_0:
-    SecretInteger: '4'
-  E_1_1:
-    SecretInteger: '5'
-  E_1_2:
-    SecretInteger: '6'
-  E_2_0:
-    SecretInteger: '7'
-  E_2_1:
-    SecretInteger: '8'
-  E_2_2:
-    SecretInteger: '9'
-  F_0:
-    SecretInteger: '1'
+  A_0_0: 1
+  A_0_1: 2
+  A_0_2: 3
+  A_1_0: 4
+  A_1_1: 5
+  A_1_2: 6
+  A_2_0: 7
+  A_2_1: 8
+  A_2_2: 9
+  B_0_0: 1
+  B_0_1: 2
+  B_0_2: 3
+  B_1_0: 4
+  B_1_1: 5
+  B_1_2: 6
+  B_2_0: 7
+  B_2_1: 8
+  B_2_2: 9
+  C_0_0: 1
+  C_0_1: 2
+  C_0_2: 3
+  C_1_0: 4
+  C_1_1: 5
+  C_1_2: 6
+  C_2_0: 7
+  C_2_1: 8
+  C_2_2: 9
+  D_0: 1
+  E_0_0: 1
+  E_0_1: 2
+  E_0_2: 3
+  E_1_0: 4
+  E_1_1: 5
+  E_1_2: 6
+  E_2_0: 7
+  E_2_1: 8
+  E_2_2: 9
+  F_0: 1
 expected_outputs:
-  out_0:
-    SecretInteger: 1
-  out_1:
-    SecretInteger: 362880
-  out_2:
-    SecretInteger: 31
-  out_3:
-    SecretInteger: 13
-  out_4:
-    SecretInteger: 21
-  out_5:
-    Integer: 42
+  out_0: 1
+  out_1: 362880
+  out_2: 31
+  out_3: 13
+  out_4: 21
+  out_5: 42

--- a/tests/nada-tests/tests/supported_operations_return_types.yaml
+++ b/tests/nada-tests/tests/supported_operations_return_types.yaml
@@ -1,91 +1,47 @@
 program: supported_operations_return_types
 inputs:
-  A_0_0:
-    SecretInteger: '1'
-  A_0_1:
-    SecretInteger: '2'
-  A_0_2:
-    SecretInteger: '3'
-  A_1_0:
-    SecretInteger: '4'
-  A_1_1:
-    SecretInteger: '5'
-  A_1_2:
-    SecretInteger: '6'
-  A_2_0:
-    SecretInteger: '7'
-  A_2_1:
-    SecretInteger: '8'
-  A_2_2:
-    SecretInteger: '9'
-  B_0_0:
-    SecretInteger: '1'
-  B_0_1:
-    SecretInteger: '2'
-  B_0_2:
-    SecretInteger: '3'
-  B_1_0:
-    SecretInteger: '4'
-  B_1_1:
-    SecretInteger: '5'
-  B_1_2:
-    SecretInteger: '6'
-  B_2_0:
-    SecretInteger: '7'
-  B_2_1:
-    SecretInteger: '8'
-  B_2_2:
-    SecretInteger: '9'
-  C_0_0:
-    SecretInteger: '1'
-  C_0_1:
-    SecretInteger: '2'
-  C_0_2:
-    SecretInteger: '3'
-  C_1_0:
-    SecretInteger: '4'
-  C_1_1:
-    SecretInteger: '5'
-  C_1_2:
-    SecretInteger: '6'
-  C_2_0:
-    SecretInteger: '7'
-  C_2_1:
-    SecretInteger: '8'
-  C_2_2:
-    SecretInteger: '9'
-  D_0:
-    SecretInteger: '1'
-  E_0_0:
-    SecretInteger: '1'
-  E_0_1:
-    SecretInteger: '2'
-  E_0_2:
-    SecretInteger: '3'
-  E_1_0:
-    SecretInteger: '4'
-  E_1_1:
-    SecretInteger: '5'
-  E_1_2:
-    SecretInteger: '6'
-  E_2_0:
-    SecretInteger: '7'
-  E_2_1:
-    SecretInteger: '8'
-  E_2_2:
-    SecretInteger: '9'
-  F_0:
-    SecretInteger: '1'
+  A_0_0: 1
+  A_0_1: 2
+  A_0_2: 3
+  A_1_0: 4
+  A_1_1: 5
+  A_1_2: 6
+  A_2_0: 7
+  A_2_1: 8
+  A_2_2: 9
+  B_0_0: 1
+  B_0_1: 2
+  B_0_2: 3
+  B_1_0: 4
+  B_1_1: 5
+  B_1_2: 6
+  B_2_0: 7
+  B_2_1: 8
+  B_2_2: 9
+  C_0_0: 1
+  C_0_1: 2
+  C_0_2: 3
+  C_1_0: 4
+  C_1_1: 5
+  C_1_2: 6
+  C_2_0: 7
+  C_2_1: 8
+  C_2_2: 9
+  D_0: 1
+  E_0_0: 1
+  E_0_1: 2
+  E_0_2: 3
+  E_1_0: 4
+  E_1_1: 5
+  E_1_2: 6
+  E_2_0: 7
+  E_2_1: 8
+  E_2_2: 9
+  F_0: 1
 expected_outputs:
-  out_0:
-    SecretInteger: 1
-  out_1:
-    SecretInteger: 362880
-  out_2:
-    SecretInteger: 31
-  out_3:
-    SecretInteger: 13
-  out_4:
-    SecretInteger: 21
-  out_5:
-    Integer: 42
+  out_0: 1
+  out_1: 362880
+  out_2: 31
+  out_3: 13
+  out_4: 21
+  out_5: 42

--- a/tests/nada-tests/tests/type_guardrails.yaml
+++ b/tests/nada-tests/tests/type_guardrails.yaml
@@ -1,15 +1,9 @@
 program: type_guardrails
 inputs:
-  A_2:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
-  A_1:
-    SecretInteger: '3'
+  A_2: 3
+  A_0: 3
+  A_1: 3
 expected_outputs:
-  my_output_1:
-    SecretInteger: '3'
-  my_output_0:
-    SecretInteger: '3'
-  my_output_2:
-    SecretInteger: '3'
+  my_output_1: 3
+  my_output_0: 3
+  my_output_2: 3

--- a/tests/nada-tests/tests/unsigned_matrix_inverse.yaml
+++ b/tests/nada-tests/tests/unsigned_matrix_inverse.yaml
@@ -1,41 +1,22 @@
 program: unsigned_matrix_inverse
 inputs:
-  A_0_0:
-    SecretUnsignedInteger: '2'
-  A_0_1:
-    SecretUnsignedInteger: '4'
-  A_0_2:
-    SecretUnsignedInteger: '6'
-  A_1_0:
-    SecretUnsignedInteger: '1'
-  A_1_1:
-    SecretUnsignedInteger: '3'
-  A_1_2:
-    SecretUnsignedInteger: '5'
-  A_2_0:
-    SecretUnsignedInteger: '3'
-  A_2_1:
-    SecretUnsignedInteger: '1'
-  A_2_2:
-    SecretUnsignedInteger: '2'
-  B:
-    UnsignedInteger: '456'
+  A_0_0: 2
+  A_0_1: 4
+  A_0_2: 6
+  A_1_0: 1
+  A_1_1: 3
+  A_1_2: 5
+  A_2_0: 3
+  A_2_1: 1
+  A_2_2: 2
+  B: 456
 expected_outputs:
-  my_output_0_0:
-    SecretUnsignedInteger: '3074457345439651158'
-  my_output_0_1:
-    SecretUnsignedInteger: '12297829381758604631'
-  my_output_0_2:
-    SecretUnsignedInteger: '6148914690879302316'
-  my_output_1_0:
-    SecretUnsignedInteger: '3074457345439651160'
-  my_output_1_1:
-    SecretUnsignedInteger: '12297829381758604629'
-  my_output_1_2:
-    SecretUnsignedInteger: '6148914690879302315'
-  my_output_2_0:
-    SecretUnsignedInteger: '12297829381758604630'
-  my_output_2_1:
-    SecretUnsignedInteger: '12297829381758604633'
-  my_output_2_2:
-    SecretUnsignedInteger: '6148914690879302316'
+  my_output_0_0: 3074457345439651158
+  my_output_0_1: 12297829381758604631
+  my_output_0_2: 6148914690879302316
+  my_output_1_0: 3074457345439651160
+  my_output_1_1: 12297829381758604629
+  my_output_1_2: 6148914690879302315
+  my_output_2_0: 12297829381758604630
+  my_output_2_1: 12297829381758604633
+  my_output_2_2: 6148914690879302316

--- a/tests/nada-tests/tests/unsigned_matrix_inverse_2.yaml
+++ b/tests/nada-tests/tests/unsigned_matrix_inverse_2.yaml
@@ -1,41 +1,22 @@
 program: unsigned_matrix_inverse
 inputs:
-  A_0_0:
-    SecretUnsignedInteger: '1'
-  A_0_1:
-    SecretUnsignedInteger: '2'
-  A_0_2:
-    SecretUnsignedInteger: '3'
-  A_1_0:
-    SecretUnsignedInteger: '4'
-  A_1_1:
-    SecretUnsignedInteger: '5'
-  A_1_2:
-    SecretUnsignedInteger: '6'
-  A_2_0:
-    SecretUnsignedInteger: '7'
-  A_2_1:
-    SecretUnsignedInteger: '8'
-  A_2_2:
-    SecretUnsignedInteger: '10'
-  B:
-    UnsignedInteger: '456'
+  A_0_0: 1
+  A_0_1: 2
+  A_0_2: 3
+  A_1_0: 4
+  A_1_1: 5
+  A_1_2: 6
+  A_2_0: 7
+  A_2_1: 8
+  A_2_2: 10
+  B: 456
 expected_outputs:
-  my_output_0_0:
-    SecretUnsignedInteger: '6148914690879302315'
-  my_output_0_1:
-    SecretUnsignedInteger: '12297829381758604630'
-  my_output_0_2:
-    SecretUnsignedInteger: '1'
-  my_output_1_0:
-    SecretUnsignedInteger: '6148914690879302315'
-  my_output_1_1:
-    SecretUnsignedInteger: '12297829381758604635'
-  my_output_1_2:
-    SecretUnsignedInteger: '18446744072637906945'
-  my_output_2_0:
-    SecretUnsignedInteger: '1'
-  my_output_2_1:
-    SecretUnsignedInteger: '18446744072637906945'
-  my_output_2_2:
-    SecretUnsignedInteger: '1'
+  my_output_0_0: 6148914690879302315
+  my_output_0_1: 12297829381758604630
+  my_output_0_2: 1
+  my_output_1_0: 6148914690879302315
+  my_output_1_1: 12297829381758604635
+  my_output_1_2: 18446744072637906945
+  my_output_2_0: 1
+  my_output_2_1: 18446744072637906945
+  my_output_2_2: 1

--- a/tests/nada-tests/tests/vstack.yaml
+++ b/tests/nada-tests/tests/vstack.yaml
@@ -1,27 +1,15 @@
 program: vstack
 inputs:
-  A_2:
-    SecretInteger: '3'
-  B_1:
-    SecretInteger: '3'
-  B_0:
-    SecretInteger: '3'
-  B_2:
-    SecretInteger: '3'
-  A_0:
-    SecretInteger: '3'
-  A_1:
-    SecretInteger: '3'
+  A_2: 3
+  B_1: 3
+  B_0: 3
+  B_2: 3
+  A_0: 3
+  A_1: 3
 expected_outputs:
-  my_output_1_2:
-    SecretInteger: '3'
-  my_output_0_1:
-    SecretInteger: '3'
-  my_output_0_0:
-    SecretInteger: '3'
-  my_output_1_0:
-    SecretInteger: '3'
-  my_output_0_2:
-    SecretInteger: '3'
-  my_output_1_1:
-    SecretInteger: '3'
+  my_output_1_2: 3
+  my_output_0_1: 3
+  my_output_0_0: 3
+  my_output_1_0: 3
+  my_output_0_2: 3
+  my_output_1_1: 3


### PR DESCRIPTION
This PR includes the changes required to update Nada-Numpy to version 0.5.0 corresponding to version 0.6.0 of Nada-DSL and Nillion Python Client.

Note: This is expected to fail before finishing we need to:
- [x] Version 0.6.0 of Nada DSL and Python Client needs to be released.
- [x] Update poetry lock: `poetry lock`
- [x] Push to and wait for CI/CD to execute.